### PR TITLE
Change Syntax

### DIFF
--- a/backup/parser_old.txt
+++ b/backup/parser_old.txt
@@ -1,0 +1,226 @@
+
+#[derive(Debug)]
+enum ParserError {
+    InvalidToken,
+    UnmatchedBracket,
+    UnexpectedVarValue,
+}
+
+fn error_to_string(error: ParserError) -> String {
+    match error {
+        ParserError::InvalidToken => { String::from("Found invalid Token when parsing!") },
+        ParserError::UnexpectedVarValue => { String::from("Found invalid Token when assigning value to variable") },
+        ParserError::UnmatchedBracket => { String::from("Could not find matching bracket") },
+        e => { unimplemented!("no error message for {:?}", e) }
+    }
+}
+
+const TWO_OP: [&str; 4] = ["+", "-", "*", "/"];
+
+/* #[derive(Debug)]
+pub struct Parser {
+    tokens: Vec<Token>,
+    ast: Option<Ast>,
+    memory_size: usize,
+    memory: Vec<u64>,
+    memory_ptr: usize,
+    mem_lookup: HashMap<String, usize>,
+    intrinsics: HashSet<String>
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        let mem_lookup = HashMap::new();
+        let mut intrinsics = HashSet::new();
+        intrinsics.extend(vec!["print"].iter().map(|s| String::from(*s)).collect::<Vec<String>>());
+        let memory_size = 128;
+        Self { tokens: vec![], memory_size, memory: vec![0; memory_size], intrinsics, memory_ptr: 0, mem_lookup, ast: None }
+    }
+
+    pub fn set_context(&mut self, tokens: Vec<Token>) {
+        self.tokens = tokens;
+    }
+
+    pub fn get_program(&self) -> (Ast, Vec<u64>, HashMap<String, usize>, HashSet<String>) {
+        if self.ast.is_none() {
+            panic!("Attempted to fetch program before parsing!");
+        }
+        (self.ast.clone().unwrap(), self.memory.clone(), self.mem_lookup.clone(), self.intrinsics.clone())
+    }
+
+    fn get_mem_id(&mut self) -> usize {
+        let m = self.memory_ptr;
+        self.memory_ptr += 1;
+        m
+    }
+
+    fn get_op_count(&self, token: &Token) -> Result<usize, String> {
+        match token.get_type() {
+            TokenType::Symbol => {
+                match token.get_value().as_str() {
+                    s if TWO_OP.contains(&s) => {
+                        Ok(2)
+                    },
+                    _ => { Err("uhh x2".to_uppercase() )}
+                }
+            },
+            _ => { Err("uhh".to_ascii_lowercase()) }
+        }
+    }
+
+    fn get_matching(&self, token_id: usize) -> Result<usize, String> {
+        let t = &self.tokens[token_id];
+        assert_eq!(t.get_type(), TokenType::OpenParenthesis);
+        let mut cnt = 1;
+        for i in (token_id+1)..self.tokens.len() {
+            let o = &self.tokens[i];
+            match o.get_type() {
+                TokenType::OpenParenthesis => { cnt += 1 },
+                TokenType::ClosingParenthesis => {
+                    cnt -= 1;
+                    if cnt == 0 {
+                        return Ok(i);
+                    }
+                },
+                _ => {}
+            }
+        }
+        Err(error_to_string(ParserError::UnmatchedBracket))
+    }
+
+    fn parse_number(&self, val: &String) -> Result<Ast, String> {
+        match val.parse() {
+            Ok(v) => { Ok(Ast::Const(v)) },
+            Err(e) => { return Err(e.to_string()); }
+        }
+    }
+
+    fn parse_variable(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
+        let mem_id = self.get_mem_id();
+        let defvar = &self.tokens[start_id];
+        assert_eq!(defvar.get_value(), String::from("defvar"));
+        let varname = &self.tokens[start_id + 1];
+        let name_as_str = varname.get_value();
+        assert_eq!(varname.get_type(), TokenType::Name);
+        let varvalue = &self.tokens[start_id + 2];
+        let (i, r) = match varvalue.get_type() {
+            TokenType::OpenParenthesis => {
+                self.parse_block(start_id + 2)?
+            },
+            TokenType::Name => {
+                todo!("Assign other variable to variable")
+            },
+            TokenType::Number => {
+                (start_id + 3, self.parse_number(&self.tokens[start_id + 2].get_value())?)
+            },
+            e => {
+                return Err(format!("Error: {}: Found `{:?}`, expected String, Number or (.", error_to_string(ParserError::UnexpectedVarValue), e).to_string());
+            }
+        };
+        self.mem_lookup.insert(name_as_str, mem_id);
+        Ok((i, Ast::Assign(mem_id, Box::new(r))))
+    }
+
+    fn parse_symbol(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
+        let symbol = &self.tokens[start_id].clone();
+        let operators = self.get_op_count(symbol)?;
+        assert_eq!(operators, 2, "There is currently no support for operations with more than 2 operands.");
+        let mut operands = vec![];
+        let mut id = start_id;
+        for _ in 0..operators {
+            let (i, ast) = match self.tokens[id + 1].get_type() {
+                TokenType::Name => {
+                    if let Some(mem_id) = self.mem_lookup.get(&self.tokens[id + 1].get_value()) {
+                        (id + 1, Ast::Var(*mem_id))
+                    } else {
+                        todo!("Handle this situation in parse_symbol: Could not find symbol in mem_lookup!")
+                    }
+                },
+                TokenType::OpenParenthesis => {
+                    self.parse_block(id + 1)?
+                },
+                TokenType::Number => {
+                    (id + 1, self.parse_number(&self.tokens[id + 1].get_value())?)
+                },
+                e => {
+                    return Err(error_to_string(ParserError::InvalidToken) + &format!(" Got: {:?}, expected String, Number or (.", e))
+                }
+            };
+            id = i;
+            operands.push(ast);
+        }
+        match symbol.get_value().as_str() {
+            "+" => { Ok((id, Ast::Add(Box::new(operands[0].clone()), Box::new(operands[1].clone())))) }
+            "-" => { Ok((id, Ast::Sub(Box::new(operands[0].clone()), Box::new(operands[1].clone())))) }
+            e => { todo!("parse_symbol() for Symbol {}", e) }
+        }
+    }
+
+    fn parse_function(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
+        let name = &self.tokens[start_id];
+        if name.get_type() != TokenType::Name {
+            return Err(error_to_string(ParserError::InvalidToken));
+        }
+        let name = name.get_value();
+        let (id, ast) = self.parse_block(start_id + 1)?;
+        Ok((id + 1, Ast::Func(name, Box::new(ast))))
+    }
+
+    fn parse_block(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
+        let end_id = self.get_matching(start_id)?;
+        // println!("Parsing tokens from indices {} to {}", start_id, end_id);
+        let mut id = start_id + 1;
+        let mut ast_vec = vec![];
+        while id < end_id {
+            let t = &self.tokens[id];
+            match t.get_type() {
+                TokenType::OpenParenthesis => {
+                    let (block_end, ast) = self.parse_block(id)?;
+                    ast_vec.push(ast);
+                    id = block_end;
+                },
+                TokenType::Name => {
+                    match t.get_value() {
+                        s if s == String::from("defvar") => {
+                            let (i, ast) = self.parse_variable(id)?;
+                            ast_vec.push(ast);
+                            id = i;
+                        },
+                        s if s == String::from("print") => {
+                            let (i, ast) = self.parse_function(id)?;
+                            ast_vec.push(ast);
+                            id = i;
+                        },
+                        v if self.mem_lookup.contains_key(&v) => {
+                            let mem_id = self.mem_lookup.get(&v).unwrap();
+                            ast_vec.push(Ast::Var(*mem_id));
+                            id += 1;
+                        }
+                        v => { return Err(error_to_string(ParserError::InvalidToken) + &format!(" Got: `{}`", v)) }
+                    }
+                },
+                TokenType::Symbol => {
+                    let (i, ast) = self.parse_symbol(id)?;
+                    ast_vec.push(ast);
+                    id = i;
+                },
+                _ => { return Err(error_to_string(ParserError::InvalidToken) + &format!(" Got: `{}`", t.get_value()))},
+            }
+            id += 1;
+        }
+        Ok((end_id, Ast::Block(ast_vec)))
+    }
+
+    pub fn parse(&mut self) -> Result<(), String> {
+        let mut id = 0;
+        let mut ast_vec = vec![];
+        while id < self.tokens.len() {
+            let (next_id, ast) = self.parse_block(id)?;
+            ast_vec.push(ast);
+            id = next_id + 1;
+        }
+        self.ast = Some(Ast::Block(ast_vec));
+        Ok(())
+    }
+}
+ */

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,26 +1,145 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::parser::{Tree, TreeType, Node};
+use crate::parser::{Tree, TreeType};
 use crate::lexer::{Token, TokenType};
 
 #[derive(Debug)]
 enum Instruction {
-    Load { dest: usize, val: u64 },
+    Load { dest: usize, val: usize },
     Add { dest: usize, src1: usize, src2: usize },
     Sub { dest: usize, src1: usize, src2: usize },
+    Mul { dest: usize, src1: usize, src2: usize },
+    Div { dest: usize, src1: usize, src2: usize },
     Copy { dest: usize, src: usize },
     Print { src: usize }
 }
 
 #[derive(Debug)]
 struct Function {
-    code: Vec<Instruction>
+    code: Vec<Instruction>,
+    mem_offset: usize,
+    local_lookup: HashMap<String, usize>
+}
+
+impl Function {
+    fn new(block: &Tree, mem_offset: usize) -> Self {
+        let mut r = Self { code: vec![], mem_offset, local_lookup: HashMap::new() };
+        r.convert(block);
+        r
+    }
+
+    fn get_mem(&mut self) -> usize {
+        let l = self.mem_offset;
+        self.mem_offset += 1;
+        l
+    }
+
+    fn get_offset(&self) -> usize {
+        self.mem_offset
+    }
+
+    fn convert_expr(&mut self, instr: &Tree) -> usize {
+        match instr.typ.as_ref().unwrap() {
+            TreeType::ExprLiteral => {
+                assert!(instr.children.len() == 1);
+                let val = instr.children[0].tkn.as_ref().unwrap().get_value().parse().unwrap();
+                let dest = self.get_mem();
+                self.code.push(Instruction::Load { dest, val });
+                return dest;
+            },
+            TreeType::ExprParen => {
+                assert!(instr.children.len() == 1);
+                return self.convert_expr(&instr.children[0]);
+            }
+            TreeType::ExprBinary => {
+                assert!(*instr.typ.as_ref().unwrap() == TreeType::ExprBinary);
+                assert!(instr.children.len() == 3);
+                let lhs = instr.children[0].as_ref();
+                let op = instr.children[1].as_ref();
+                let rhs = instr.children[2].as_ref();
+                let lhs_src = self.convert_expr(lhs);
+                let rhs_src = self.convert_expr(rhs);
+                let dst = self.get_mem();
+                match op.tkn.as_ref().unwrap().get_type() {
+                    TokenType::Plus => self.code.push(Instruction::Add { dest: dst, src1: lhs_src, src2: rhs_src }),
+                    TokenType::Minus => self.code.push(Instruction::Sub { dest: dst, src1: lhs_src, src2: rhs_src }),
+                    TokenType::Mult => self.code.push(Instruction::Mul { dest: dst, src1: lhs_src, src2: rhs_src }),
+                    TokenType::Div => self.code.push(Instruction::Div { dest: dst, src1: lhs_src, src2: rhs_src }),
+                    e => todo!("Handle {:?} in convert_expr()", e)
+                }
+                return dst;
+            },
+            TreeType::ExprName => {
+                assert!(instr.children.len() == 1);
+                let val_name = &instr.children[0];
+                let name = val_name.tkn.as_ref().unwrap().get_value();
+                if self.local_lookup.contains_key(&name) {
+                    let dst = self.get_mem();
+                    let src = *self.local_lookup.get(&name).unwrap();
+                    self.code.push(Instruction::Copy { dest: dst, src });
+                    return dst;
+                }
+                panic!("Local lookup does not contain the variable!");
+            },
+            e => todo!("Handle {:?} in convert_expr. Got:\n{:?}", e, instr)
+        }
+    }
+
+    fn convert_assignment(&mut self, instr: &Tree) -> usize {
+        let eq = &instr.children[2];
+        assert!(eq.tkn.as_ref().unwrap().get_type() == TokenType::Equal);
+        let rhs = &instr.children[3];
+        match &rhs.typ {
+            Some(t) => {
+                match t {
+                    TreeType::ExprLiteral
+                    | TreeType::ExprBinary => {
+                        return self.convert_expr(rhs);
+                    }
+                    e => todo!("Handle {:?} in convert_assignment", e)
+                }
+            },
+            e => todo!("Handle {:?} in convert_assignment", e)
+        }
+        unreachable!()
+    }
+
+    fn convert_let(&mut self, instr: &Tree) {
+        let instr_children = &instr.children;
+        let let_keyword = &instr_children[0];
+        assert!(let_keyword.tkn.as_ref().unwrap().get_type() == TokenType::LetKeyword);
+        let let_name = &instr_children[1];
+        assert!(let_name.tkn.as_ref().unwrap().get_type() == TokenType::Name);
+        let let_name = let_name.tkn.as_ref().unwrap();
+        if self.local_lookup.contains_key(&let_name.get_value()) {
+            panic!("Variable redefinition in function");
+        }
+        let dest = self.get_mem();
+        self.local_lookup.insert(let_name.get_value(), dest);
+        let src = self.convert_assignment(instr);
+        self.code.push(Instruction::Copy { dest, src });
+    }
+
+    fn convert(&mut self, block: &Tree) {
+        assert!(*block.typ.as_ref().unwrap() == TreeType::Block);
+        for instr in &block.children {
+            match &instr.typ {
+                Some(t) => {
+                    match t {
+                        TreeType::StmtLet => self.convert_let(instr),
+                        e => todo!("convert {:?} to function", e)
+                    }
+                },
+                _ => panic!()
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
 pub struct Generator {
     ast: Tree,
-    memory: Vec<u64>,
+    memory: Vec<usize>,
     functions: HashMap<String, Function>,
     register_count: usize
 }
@@ -32,15 +151,40 @@ impl Generator {
         gen
     }
 
+    fn convert_fn(&mut self, func: &Tree) {
+        let fn_children = &func.children;
+        assert!(fn_children.len() == 3, "fnKeyword fnName {{block}} expected.");
+        let fn_keyword = fn_children[0].tkn.as_ref().unwrap();
+        assert!(fn_keyword.get_type() == TokenType::FnKeyword);
+        let fn_name = fn_children[1].tkn.as_ref().unwrap();
+        assert!(fn_name.get_type() == TokenType::Name);
+        if self.functions.contains_key(&fn_name.get_value()) {
+            panic!("Function redefinition!!");
+        }
+        let block = fn_children[2].typ.as_ref().unwrap();
+        let mem_size = self.memory.len();
+        let f = Function::new(&fn_children[2], mem_size);
+        let local_mem_size = f.get_offset() - mem_size;
+        for _ in 0..local_mem_size { self.memory.push(0); }
+        self.functions.insert(fn_name.get_value(), f);
+        assert!(*block == TreeType::Block);
+    }
+
     fn convert_ast(&mut self, ast: &Tree) {
-        match ast.typ {
-            TreeType::File => {
-                // for func in &ast.children {
-                //     self.convert_func(func);
-                // }
-                todo!()
+        match &ast.typ {
+            Some(typ) => {
+                match typ {
+                    TreeType::File => {
+                        for func in &ast.children {
+                            self.convert_fn(func);
+                        }
+                    },
+                    _ => todo!("handle other types")
+                }
+            },
+            None => {
+                panic!()
             }
-            _ => todo!("handle {ast:?}")
         }
     }
 
@@ -58,7 +202,45 @@ impl Generator {
         self.convert_ast(&self.ast.clone());
     }
 
+    fn interpret_function(&mut self, fn_name: &String) {
+        assert!(self.functions.contains_key(fn_name));
+        let f = self.functions.get(fn_name).unwrap();
+        for instr in &f.code {
+            println!("{:?}", instr);
+            match instr {
+                Instruction::Add { dest, src1, src2 } => {
+                    self.memory[*dest] = self.memory[*src1] + self.memory[*src2];
+                },
+                Instruction::Sub { dest, src1, src2 } => {
+                    self.memory[*dest] = self.memory[*src1] - self.memory[*src2];
+                },
+                Instruction::Mul { dest, src1, src2 } => {
+                    self.memory[*dest] = self.memory[*src1] * self.memory[*src2];
+                },
+                Instruction::Div { dest, src1, src2 } => {
+                    self.memory[*dest] = self.memory[*src1] / self.memory[*src2];
+                },
+                Instruction::Copy { dest, src } => {
+                    self.memory[*dest] = self.memory[*src];
+                },
+                Instruction::Load { dest, val } => {
+                    self.memory[*dest] = *val;
+                }
+                Instruction::Print { src } => todo!(),
+            }
+        }
+    }
+
     pub fn interpret(&mut self) -> Result<(), String> {
-        todo!()
+        let main = String::from("main");
+        if self.functions.contains_key(&main) {
+            self.interpret_function(&main);
+        }
+        for f in &self.functions {
+            for v in &f.1.local_lookup {
+                println!("{:10} - {} = {:3}", f.0, v.0, self.memory[*v.1]);
+            }
+        }
+        Ok(())
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::parser::Ast;
+use crate::parser::{Tree, TreeType, Node};
+use crate::lexer::{Token, TokenType};
 
 #[derive(Debug)]
 enum Instruction {
@@ -12,80 +13,34 @@ enum Instruction {
 }
 
 #[derive(Debug)]
+struct Function {
+    code: Vec<Instruction>
+}
+
+#[derive(Debug)]
 pub struct Generator {
-    ast: Ast,
+    ast: Tree,
     memory: Vec<u64>,
-    intrinsics: HashSet<String>,
-    code: Vec<Instruction>,
+    functions: HashMap<String, Function>,
     register_count: usize
 }
 
 impl Generator {
-    pub fn new(program: (Ast, Vec<u64>, HashMap<String, usize>, HashSet<String>), local_count: usize) -> Self {
-        let mut gen = Self { ast: program.0, memory: program.1, intrinsics: program.3, code: vec![], register_count: local_count };
+    pub fn new(ast: Tree, local_count: usize) -> Self {
+        let mut gen = Self { ast, memory: vec![], functions: HashMap::new(), register_count: local_count };
         gen.generate_code();
         gen
     }
 
-    fn convert_ast(&mut self, ast: &Ast) -> usize {
-        match ast {
-            Ast::Const(value) => {
-                let dest = self.allocate_register();
-                self.add_instruction(Instruction::Load { dest, val: *value } );
-                dest
-            },
-            Ast::Assign(mem, value) => {
-                let src = self.convert_ast(value);
-                let dest = *mem;
-                self.add_instruction(Instruction::Copy { dest, src } );
-                usize::MAX
-            },
-            Ast::Var(mem) => {
-                let src = *mem;
-                let dest = self.allocate_register();
-                self.add_instruction(Instruction::Copy { dest, src });
-                dest
-            },
-            Ast::Add(lhs, rhs) => {
-                let src1 = self.convert_ast(lhs);
-                let src2 = self.convert_ast(rhs);
-                let dest = self.allocate_register();
-                self.add_instruction(Instruction::Add { dest, src1, src2 } );
-                dest
-            },
-            Ast::Sub(lhs, rhs) => {
-                let src1 = self.convert_ast(lhs);
-                let src2 = self.convert_ast(rhs);
-                let dest = self.allocate_register();
-                self.add_instruction(Instruction::Sub { dest, src1, src2 } );
-                dest
-            },
-            Ast::Func(name, ast) => {
-                match name {
-                    intrinsic if self.intrinsics.contains(name) => {
-                        match intrinsic.as_str() {
-                            "print"=> {
-                                let src = self.convert_ast(ast);
-                                self.add_instruction(Instruction::Print { src } );
-                                usize::MAX
-                            },
-                            _ => {
-                                unreachable!("There's only {} intrinsic, and it's all handled.", self.intrinsics.len());
-                            }
-                        }
-                    },
-                    _ => {
-                        todo!("Handle generic functions");
-                    }
-                }
+    fn convert_ast(&mut self, ast: &Tree) {
+        match ast.typ {
+            TreeType::File => {
+                // for func in &ast.children {
+                //     self.convert_func(func);
+                // }
+                todo!()
             }
-            Ast::Block(ast_vec) => {
-                let mut max = 0;
-                for a in ast_vec {
-                    max = max.max(self.convert_ast(a));
-                }
-                max
-            },
+            _ => todo!("handle {ast:?}")
         }
     }
 
@@ -95,40 +50,15 @@ impl Generator {
         result
     }
 
-    fn add_instruction(&mut self, instr: Instruction) {
-        self.code.push(instr);
-    }
+    // fn add_instruction(&mut self, instr: Instruction) {
+    //     self.code.push(instr);
+    // }
 
     fn generate_code(&mut self) {
         self.convert_ast(&self.ast.clone());
     }
 
     pub fn interpret(&mut self) -> Result<(), String> {
-        // println!("{:?}", self.memory);
-        for instr in &self.code {
-            // println!("{:?}", instr);
-            match *instr {
-                Instruction::Copy { dest, src } => {
-                    self.memory[dest] = self.memory[src];
-                },
-                Instruction::Load { dest, val } => {
-                    self.memory[dest] = val;
-                },
-                Instruction::Add { dest, src1, src2 } => {
-                    let l = self.memory[src1];
-                    let r = self.memory[src2];
-                    self.memory[dest] = l + r;
-                },
-                Instruction::Sub { dest, src1, src2 } => {
-                    let l = self.memory[src1];
-                    let r = self.memory[src2];
-                    self.memory[dest] = l - r;
-                },
-                Instruction::Print { src } => {
-                    println!("{}", self.memory[src]);
-                }
-            }
-        }
-        Ok(())
+        todo!()
     }
 }

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -1,0 +1,9 @@
+
+Block = ("(", Stmt*, ")");
+
+Stmt = Stmt_expr;
+
+Stmt_expr = Expr + ";";
+
+Expr = ExprName;
+ExprName = "name";

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -9,6 +9,11 @@ Stmt = StmtExpr | StmtLet;
 StmtExpr = Expr ";";
 StmtLet = "let" "name" "=" Expr ";";
 
-Expr = ExprName | ExprLiteral;
+Expr = ExprName
+     | ExprLiteral
+     | ExprBinary
+     | ExprParen;
 ExprName = "name";
 ExprLiteral = "int";
+ExprBinary = Expr ("+" | "-" | "*" | "/") Expr;
+ExprParen = "(" Expr ")";

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -1,9 +1,14 @@
+File: Fn*;
 
-Block = ("(", Stmt*, ")");
+Fn = "func" "name" "(" ")" "{" Block "}";
 
-Stmt = Stmt_expr;
+Block = (Stmt*);
 
-Stmt_expr = Expr + ";";
+Stmt = StmtExpr | StmtLet;
 
-Expr = ExprName;
+StmtExpr = Expr ";";
+StmtLet = "let" "name" "=" Expr ";";
+
+Expr = ExprName | ExprLiteral;
 ExprName = "name";
+ExprLiteral = "int";

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -12,14 +12,17 @@ fn error_to_string(err: LexerError) -> String {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TokenType {
     Invalid,
+    IntLiteral,
+    OpenParenthesis, ClosingParenthesis,
+    OpenBracket, ClosingBracket,
+    FnKeyword, LetKeyword,
+    Equal, Plus, Minus,
+    Semi,
     Name,
-    Number,
-    OpenParenthesis,
-    ClosingParenthesis,
-    Symbol
+    EOF
 }
 
 #[derive(Debug, Clone)]
@@ -31,7 +34,7 @@ struct Location {
 
 #[derive(Debug, Clone)]
 pub struct Token {
-    typ: TokenType, // type is a reserved keyword in Rust :(
+    pub typ: TokenType, // type is a reserved keyword in Rust :(
     value: String,
     loc: Location
 }
@@ -59,12 +62,8 @@ pub struct Lexer {
 impl Lexer {
     pub fn new(origin_path: &String) -> Result<Self, String> {
         match fs::read_to_string(origin_path) {
-            Ok(source) => {
-                Ok(Lexer { origin: origin_path.to_string(), source: source.chars().collect(), tokens: vec![], current_char: 0, current_line: 1, line_start: 0 })
-            },
-            Err(e) => {
-                Err(e.to_string())
-            }
+            Ok(source) => Ok(Lexer { origin: origin_path.to_string(), source: source.chars().collect(), tokens: vec![], current_char: 0, current_line: 1, line_start: 0 }),
+            Err(e) => Err(e.to_string())
         }
     }
 
@@ -109,7 +108,7 @@ impl Lexer {
                     }
                     value.push(nc);
                 }
-                Ok( Token { typ: TokenType::Number, value, loc: self.get_location() } )
+                Ok( Token { typ: TokenType::IntLiteral, value, loc: self.get_location() } )
             },
             'A'..='z' => {
                 let mut value = String::from(c);
@@ -120,20 +119,22 @@ impl Lexer {
                     }
                     value.push(nc);
                 }
-                Ok( Token { typ: TokenType::Name, value, loc: self.get_location() } )
+                let typ = match value.as_str() {
+                    "func" => TokenType::FnKeyword,
+                    "let" => TokenType::LetKeyword,
+                    _ => TokenType::Name
+                };
+                Ok( Token { typ, value, loc: self.get_location() } )
             },
-            '(' => {
-                Ok( Token { typ: TokenType::OpenParenthesis, value: String::from("("), loc: self.get_location() } )
-            },
-            ')' => {
-                Ok( Token { typ: TokenType::ClosingParenthesis, value: String::from(")"), loc: self.get_location() } )
-            },
-            '=' | '+' | '-' => {
-                Ok( Token { typ: TokenType::Symbol, value: String::from(c), loc: self.get_location() } )
-            },
-            e => {
-                Ok( Token { typ: TokenType::Invalid, value: String::from(e), loc: self.get_location() } )
-            }
+            '(' => Ok( Token { typ: TokenType::OpenParenthesis, value: String::from("("), loc: self.get_location() } ),
+            ')' => Ok( Token { typ: TokenType::ClosingParenthesis, value: String::from(")"), loc: self.get_location() } ),
+            '{' => Ok( Token { typ: TokenType::OpenBracket, value: String::from("{"), loc: self.get_location() } ),
+            '}' => Ok( Token { typ: TokenType::ClosingBracket, value: String::from("}"), loc: self.get_location() } ),
+            ';' => Ok( Token { typ: TokenType::Semi, value: String::from(";"), loc: self.get_location() } ),
+            '=' => Ok( Token { typ: TokenType::Equal, value: String::from(c), loc: self.get_location() } ),
+            '+' => Ok( Token { typ: TokenType::Plus, value: String::from(c), loc: self.get_location() } ),
+            '-' => Ok( Token { typ: TokenType::Minus, value: String::from(c), loc: self.get_location() } ),
+            e => Ok( Token { typ: TokenType::Invalid, value: String::from(e), loc: self.get_location() } )
         }
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -19,7 +19,7 @@ pub enum TokenType {
     OpenParenthesis, ClosingParenthesis,
     OpenBracket, ClosingBracket,
     FnKeyword, LetKeyword,
-    Equal, Plus, Minus,
+    Equal, Plus, Minus, Mult, Div,
     Semi,
     Name,
     EOF
@@ -134,6 +134,8 @@ impl Lexer {
             '=' => Ok( Token { typ: TokenType::Equal, value: String::from(c), loc: self.get_location() } ),
             '+' => Ok( Token { typ: TokenType::Plus, value: String::from(c), loc: self.get_location() } ),
             '-' => Ok( Token { typ: TokenType::Minus, value: String::from(c), loc: self.get_location() } ),
+            '*' => Ok( Token { typ: TokenType::Mult, value: String::from(c), loc: self.get_location() } ),
+            '/' => Ok( Token { typ: TokenType::Div, value: String::from(c), loc: self.get_location() } ),
             e => Ok( Token { typ: TokenType::Invalid, value: String::from(e), loc: self.get_location() } )
         }
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -34,7 +34,7 @@ struct Location {
 
 #[derive(Debug, Clone)]
 pub struct Token {
-    pub typ: TokenType, // type is a reserved keyword in Rust :(
+    typ: TokenType, // type is a reserved keyword in Rust :(
     value: String,
     loc: Location
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,9 @@ fn main() -> Result<(), String> {
     parser.parse_file();
     let ast = parser.build_tree();
     println!("{:#?}", ast);
-    // let program = parser.get_program();
 
-    // let mut generator = Generator::new(program, 3);
-    // generator.interpret()?;
+    let mut generator = Generator::new(ast, 3);
+    generator.interpret()?;
 
     println!("{:?}", now.elapsed());
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,16 @@ fn main() -> Result<(), String> {
 
     let mut lexer = Lexer::new(&path)?;
     lexer.tokenize()?;
+    println!("{:?}", lexer.get_tokens());
 
-    let mut parser = Parser::new();
-    parser.set_context(lexer.get_tokens());
-    parser.parse()?;
-    let program = parser.get_program();
+    let mut parser = Parser::new(lexer.get_tokens());
+    parser.parse_file();
+    let ast = parser.build_tree();
+    println!("{:#?}", ast);
+    // let program = parser.get_program();
 
-    let mut generator = Generator::new(program, 3);
-    generator.interpret()?;
+    // let mut generator = Generator::new(program, 3);
+    // generator.interpret()?;
 
     println!("{:?}", now.elapsed());
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,12 @@ fn main() -> Result<(), String> {
 
     let mut lexer = Lexer::new(&path)?;
     lexer.tokenize()?;
-    println!("{:?}", lexer.get_tokens());
+    // println!("{:?}", lexer.get_tokens());
 
     let mut parser = Parser::new(lexer.get_tokens());
     parser.parse_file();
     let ast = parser.build_tree();
-    println!("{:#?}", ast);
+    // println!("{:#?}", ast);
 
     let mut generator = Generator::new(ast, 3);
     generator.interpret()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,14 +26,9 @@ pub enum TreeType {
 
 #[derive(Debug, Clone)]
 pub struct Tree {
-    pub typ: TreeType,
-    pub children: Vec<Node>,
-}
-
-#[derive(Debug, Clone)]
-pub enum Node {
-    Token(Token),
-    Tree(Tree)
+    pub typ: Option<TreeType>,
+    pub tkn: Option<Token>,
+    pub children: Vec<Box<Tree>>,
 }
 
 enum Event {
@@ -49,232 +44,6 @@ struct MarkOpened {
 struct MarkClosed {
     index: usize,
 }
-
-#[derive(Debug)]
-enum ParserError {
-    InvalidToken,
-    UnmatchedBracket,
-    UnexpectedVarValue,
-}
-
-fn error_to_string(error: ParserError) -> String {
-    match error {
-        ParserError::InvalidToken => { String::from("Found invalid Token when parsing!") },
-        ParserError::UnexpectedVarValue => { String::from("Found invalid Token when assigning value to variable") },
-        ParserError::UnmatchedBracket => { String::from("Could not find matching bracket") },
-        e => { unimplemented!("no error message for {:?}", e) }
-    }
-}
-
-const TWO_OP: [&str; 4] = ["+", "-", "*", "/"];
-
-/* #[derive(Debug)]
-pub struct Parser {
-    tokens: Vec<Token>,
-    ast: Option<Ast>,
-    memory_size: usize,
-    memory: Vec<u64>,
-    memory_ptr: usize,
-    mem_lookup: HashMap<String, usize>,
-    intrinsics: HashSet<String>
-}
-
-impl Parser {
-    pub fn new() -> Self {
-        let mem_lookup = HashMap::new();
-        let mut intrinsics = HashSet::new();
-        intrinsics.extend(vec!["print"].iter().map(|s| String::from(*s)).collect::<Vec<String>>());
-        let memory_size = 128;
-        Self { tokens: vec![], memory_size, memory: vec![0; memory_size], intrinsics, memory_ptr: 0, mem_lookup, ast: None }
-    }
-
-    pub fn set_context(&mut self, tokens: Vec<Token>) {
-        self.tokens = tokens;
-    }
-
-    pub fn get_program(&self) -> (Ast, Vec<u64>, HashMap<String, usize>, HashSet<String>) {
-        if self.ast.is_none() {
-            panic!("Attempted to fetch program before parsing!");
-        }
-        (self.ast.clone().unwrap(), self.memory.clone(), self.mem_lookup.clone(), self.intrinsics.clone())
-    }
-
-    fn get_mem_id(&mut self) -> usize {
-        let m = self.memory_ptr;
-        self.memory_ptr += 1;
-        m
-    }
-
-    fn get_op_count(&self, token: &Token) -> Result<usize, String> {
-        match token.get_type() {
-            TokenType::Symbol => {
-                match token.get_value().as_str() {
-                    s if TWO_OP.contains(&s) => {
-                        Ok(2)
-                    },
-                    _ => { Err("uhh x2".to_uppercase() )}
-                }
-            },
-            _ => { Err("uhh".to_ascii_lowercase()) }
-        }
-    }
-
-    fn get_matching(&self, token_id: usize) -> Result<usize, String> {
-        let t = &self.tokens[token_id];
-        assert_eq!(t.get_type(), TokenType::OpenParenthesis);
-        let mut cnt = 1;
-        for i in (token_id+1)..self.tokens.len() {
-            let o = &self.tokens[i];
-            match o.get_type() {
-                TokenType::OpenParenthesis => { cnt += 1 },
-                TokenType::ClosingParenthesis => {
-                    cnt -= 1;
-                    if cnt == 0 {
-                        return Ok(i);
-                    }
-                },
-                _ => {}
-            }
-        }
-        Err(error_to_string(ParserError::UnmatchedBracket))
-    }
-
-    fn parse_number(&self, val: &String) -> Result<Ast, String> {
-        match val.parse() {
-            Ok(v) => { Ok(Ast::Const(v)) },
-            Err(e) => { return Err(e.to_string()); }
-        }
-    }
-
-    fn parse_variable(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
-        let mem_id = self.get_mem_id();
-        let defvar = &self.tokens[start_id];
-        assert_eq!(defvar.get_value(), String::from("defvar"));
-        let varname = &self.tokens[start_id + 1];
-        let name_as_str = varname.get_value();
-        assert_eq!(varname.get_type(), TokenType::Name);
-        let varvalue = &self.tokens[start_id + 2];
-        let (i, r) = match varvalue.get_type() {
-            TokenType::OpenParenthesis => {
-                self.parse_block(start_id + 2)?
-            },
-            TokenType::Name => {
-                todo!("Assign other variable to variable")
-            },
-            TokenType::Number => {
-                (start_id + 3, self.parse_number(&self.tokens[start_id + 2].get_value())?)
-            },
-            e => {
-                return Err(format!("Error: {}: Found `{:?}`, expected String, Number or (.", error_to_string(ParserError::UnexpectedVarValue), e).to_string());
-            }
-        };
-        self.mem_lookup.insert(name_as_str, mem_id);
-        Ok((i, Ast::Assign(mem_id, Box::new(r))))
-    }
-
-    fn parse_symbol(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
-        let symbol = &self.tokens[start_id].clone();
-        let operators = self.get_op_count(symbol)?;
-        assert_eq!(operators, 2, "There is currently no support for operations with more than 2 operands.");
-        let mut operands = vec![];
-        let mut id = start_id;
-        for _ in 0..operators {
-            let (i, ast) = match self.tokens[id + 1].get_type() {
-                TokenType::Name => {
-                    if let Some(mem_id) = self.mem_lookup.get(&self.tokens[id + 1].get_value()) {
-                        (id + 1, Ast::Var(*mem_id))
-                    } else {
-                        todo!("Handle this situation in parse_symbol: Could not find symbol in mem_lookup!")
-                    }
-                },
-                TokenType::OpenParenthesis => {
-                    self.parse_block(id + 1)?
-                },
-                TokenType::Number => {
-                    (id + 1, self.parse_number(&self.tokens[id + 1].get_value())?)
-                },
-                e => {
-                    return Err(error_to_string(ParserError::InvalidToken) + &format!(" Got: {:?}, expected String, Number or (.", e))
-                }
-            };
-            id = i;
-            operands.push(ast);
-        }
-        match symbol.get_value().as_str() {
-            "+" => { Ok((id, Ast::Add(Box::new(operands[0].clone()), Box::new(operands[1].clone())))) }
-            "-" => { Ok((id, Ast::Sub(Box::new(operands[0].clone()), Box::new(operands[1].clone())))) }
-            e => { todo!("parse_symbol() for Symbol {}", e) }
-        }
-    }
-
-    fn parse_function(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
-        let name = &self.tokens[start_id];
-        if name.get_type() != TokenType::Name {
-            return Err(error_to_string(ParserError::InvalidToken));
-        }
-        let name = name.get_value();
-        let (id, ast) = self.parse_block(start_id + 1)?;
-        Ok((id + 1, Ast::Func(name, Box::new(ast))))
-    }
-
-    fn parse_block(&mut self, start_id: usize) -> Result<(usize, Ast), String> {
-        let end_id = self.get_matching(start_id)?;
-        // println!("Parsing tokens from indices {} to {}", start_id, end_id);
-        let mut id = start_id + 1;
-        let mut ast_vec = vec![];
-        while id < end_id {
-            let t = &self.tokens[id];
-            match t.get_type() {
-                TokenType::OpenParenthesis => {
-                    let (block_end, ast) = self.parse_block(id)?;
-                    ast_vec.push(ast);
-                    id = block_end;
-                },
-                TokenType::Name => {
-                    match t.get_value() {
-                        s if s == String::from("defvar") => {
-                            let (i, ast) = self.parse_variable(id)?;
-                            ast_vec.push(ast);
-                            id = i;
-                        },
-                        s if s == String::from("print") => {
-                            let (i, ast) = self.parse_function(id)?;
-                            ast_vec.push(ast);
-                            id = i;
-                        },
-                        v if self.mem_lookup.contains_key(&v) => {
-                            let mem_id = self.mem_lookup.get(&v).unwrap();
-                            ast_vec.push(Ast::Var(*mem_id));
-                            id += 1;
-                        }
-                        v => { return Err(error_to_string(ParserError::InvalidToken) + &format!(" Got: `{}`", v)) }
-                    }
-                },
-                TokenType::Symbol => {
-                    let (i, ast) = self.parse_symbol(id)?;
-                    ast_vec.push(ast);
-                    id = i;
-                },
-                _ => { return Err(error_to_string(ParserError::InvalidToken) + &format!(" Got: `{}`", t.get_value()))},
-            }
-            id += 1;
-        }
-        Ok((end_id, Ast::Block(ast_vec)))
-    }
-
-    pub fn parse(&mut self) -> Result<(), String> {
-        let mut id = 0;
-        let mut ast_vec = vec![];
-        while id < self.tokens.len() {
-            let (next_id, ast) = self.parse_block(id)?;
-            ast_vec.push(ast);
-            id = next_id + 1;
-        }
-        self.ast = Some(Ast::Block(ast_vec));
-        Ok(())
-    }
-}
- */
 
 pub struct Parser {
     tokens: Vec<Token>,
@@ -325,7 +94,7 @@ impl Parser {
             panic!("Parser is stuck at {}", self.ptr);
         }
         self.fuel.set(self.fuel.get() - 1);
-        self.tokens.get(self.ptr + lookahead).map_or(TokenType::EOF, |it|it.typ)
+        self.tokens.get(self.ptr + lookahead).map_or(TokenType::EOF, |it|it.get_type())
     }
 
     fn at(&self, typ: TokenType) -> bool {
@@ -490,21 +259,21 @@ impl Parser {
         for event in events {
             match event {
                 Event::Open { typ } => {
-                    stack.push(Tree { typ, children: Vec::new() })
+                    stack.push(Tree { typ: Some(typ), tkn: None, children: Vec::new() })
                 },
                 Event::Close => {
                     let t = stack.pop().unwrap();
-                    stack.last_mut().unwrap().children.push(Node::Tree(t))
+                    stack.last_mut().unwrap().children.push(Box::new(t))
                 },
                 Event::Advance => {
                     let t = tokens.next().unwrap();
-                    match t.typ {
+                    match t.get_type() {
                         TokenType::ClosingBracket
                         | TokenType::ClosingParenthesis
                         | TokenType::OpenBracket
                         | TokenType::OpenParenthesis
                         | TokenType::Semi => {}, // There's no reason to clutter the AST with this
-                        _ => stack.last_mut().unwrap().children.push(Node::Token(t))
+                        _ => stack.last_mut().unwrap().children.push(Box::new(Tree { typ: None, tkn: Some(t), children: vec![] }))
                     }
                 }
             }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,4 +1,9 @@
 func main() {
     let a = 5;
     let b = (a + 3) * a;
+    let c = 100 * a - b;
+}
+
+func otherFunc() {
+    let a = 5;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,3 +1,4 @@
 func main() {
     let a = 5;
+    let b = (a + 3) * a;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,4 +1,3 @@
-(defvar a 34)
-(defvar b 35)
-(defvar c (+ a b))
-(print (c))
+func main() {
+    let a = 5;
+}


### PR DESCRIPTION
We're now using an actual C-style syntax.
Used <https://matklad.github.io/2023/05/21/resilient-ll-parsing-tutorial.html> as a base.
Codegen also needed to be changed, which was a real challenge. But it appears to be working (for now)