### PR TITLE
Add Return Keyword

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -452,6 +452,18 @@ impl Generator {
         Ok(())
     }
 
+    fn convert_stmt_return(&mut self, ret_tree: &Tree) -> Result<(), String> {
+        println!("{:#?}", ret_tree);
+        match ret_tree.children.len() {
+            1 => {
+                self.code.push(Instruction::Return {  });
+                Ok(())
+            },
+            2 => todo!("Handle return statement with return value."),
+            _ => panic!()
+        }
+    }
+
     fn resolve_last_jmp(&mut self) -> usize {
         assert!(!self.unresolved_jmp_instr.is_empty());
         let ip = self.unresolved_jmp_instr.pop_back().unwrap();
@@ -550,6 +562,7 @@ impl Generator {
                     TreeType::StmtAssign => self.convert_stmt_assign(instr)?,
                     TreeType::StmtCall => self.convert_stmt_call(instr)?,
                     TreeType::StmtIf => self.convert_stmt_if(instr)?,
+                    TreeType::StmtReturn => self.convert_stmt_return(instr)?,
                     e => todo!("convert {:?} inside block", e),
                 },
                 _ => panic!(),

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -453,15 +453,17 @@ impl Generator {
     }
 
     fn convert_stmt_return(&mut self, ret_tree: &Tree) -> Result<(), String> {
-        println!("{:#?}", ret_tree);
-        match ret_tree.children.len() {
-            1 => {
-                self.code.push(Instruction::Return {  });
-                Ok(())
-            },
-            2 => todo!("Handle return statement with return value."),
-            _ => panic!()
+        let child_count = ret_tree.children.len();
+        assert!(&[1,2].contains(&child_count));
+        if child_count == 2 {
+            let reg = self.convert_expr(&ret_tree.children[1])?;
+            // Assertion for two reasons:
+            // 1: Register 0 is always the result for the outermost expr
+            // 2: Calling conventions -> Reg 0 (RAX/EAX/...) always contains return value
+            assert!(reg == 0);
         }
+        self.code.push(Instruction::Return {} );
+        Ok(())
     }
 
     fn resolve_last_jmp(&mut self) -> usize {
@@ -760,7 +762,7 @@ impl Generator {
                     // where only one element is on the return_stack
                     stack_ptr += return_stack.pop_back().unwrap();
                     ip = return_stack.pop_back().unwrap();
-                } // Instruction::Print { src: _src } => todo!(),
+                }
             }
             if add_ip {
                 ip += 1;

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -18,6 +18,7 @@ StmtLet = "let" "name" "=" Expr ";";
 StmtAssign = "name" "=" Expr ";";
 StmtCall = "name" ArgList ";";
 StmtIf = "if" "(" Expr ")" Block {"else" Block};
+StmtReturn = "return" [Expr] ";";
 
 Arg = Expr [","];
 ArgList = "(" {Arg} ")";

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -14,6 +14,7 @@ pub enum TokenType {
     LetKeyword,
     IfKeyword,
     ElseKeyword,
+    ReturnKeyword,
     Equal,
     Plus,
     Minus,
@@ -136,7 +137,7 @@ impl Lexer {
     fn next_token(&mut self) -> Result<Token, String> {
         assert_eq!(
             TokenType::Eof as u8 + 1,
-            24,
+            25,
             "Not all TokenTypes are handled in next_token()"
         );
         let c = self.next_char()?;
@@ -170,6 +171,7 @@ impl Lexer {
                     "let" => TokenType::LetKeyword,
                     "if" => TokenType::IfKeyword,
                     "else" => TokenType::ElseKeyword,
+                    "return" => TokenType::ReturnKeyword,
                     _ => TokenType::Name,
                 };
                 Ok(Token {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,6 +18,7 @@ pub enum TreeType {
     StmtAssign,
     StmtCall,
     StmtIf,
+    StmtReturn,
     ExprName,
     ExprLiteral,
     ExprBinary,
@@ -291,6 +292,17 @@ impl Parser {
         Ok(())
     }
 
+    fn parse_stmt_return(&mut self) -> Result<(), String> {
+        let m = self.open();
+        self.expect(TokenType::ReturnKeyword)?;
+        if !self.eat(TokenType::Semi) {
+            self.parse_expr()?;
+            self.expect(TokenType::Semi)?;
+        }
+        self.close(m, TreeType::StmtReturn);
+        Ok(())
+    }
+
     fn parse_block(&mut self) -> Result<(), String> {
         if !self.at(TokenType::OpenBracket) {
             let ptr = if self.ptr == self.tokens.len() {
@@ -312,6 +324,7 @@ impl Parser {
             match self.nth(0) {
                 TokenType::LetKeyword => self.parse_stmt_let()?,
                 TokenType::IfKeyword => self.parse_stmt_if()?,
+                TokenType::ReturnKeyword => self.parse_stmt_return()?,
                 TokenType::Name => match self.nth(1) {
                     TokenType::OpenParenthesis => self.parse_stmt_call()?,
                     _ => self.parse_stmt_assign()?,
@@ -359,7 +372,7 @@ impl Parser {
     pub fn parse_file(&mut self) -> Result<(), String> {
         assert_eq!(
             TokenType::Eof as u8 + 1,
-            24,
+            25,
             "Not all TokenTypes are handled in parse_file()"
         );
         let m = self.open();

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,16 +1,12 @@
-func factorial(n, acc) {
-    let c = acc;
-    if (n > 0) {
-        factorial(n - 1, c * n);
-        let d = 5;
-    } else {
-        let c = 42069;
+func test(a) {
+    if (a == 4) {
+        let b = 4;
+        return;
     }
-    c = 1337;
+    test(a + 1);
+    let c = a;
 }
 
 func main() {
-    let a = 10;
-    factorial(a, 1);
-    let b = a;
+    test(3);
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,10 +1,8 @@
 func test(a) {
-    if (a == 4) {
-        let b = 4;
-        return;
+    if (a == 2) {
+        return 5;
     }
-    test(a + 1);
-    let c = a;
+    return;
 }
 
 func main() {


### PR DESCRIPTION
Implement #3

Add support for `return;` and `return expr;` statements.
Following usual calling conventions, `return expr` always stores the return value in Register 0.

NOTE: Return values are currently ignored, as FnCalls are still treated as Stmt instead of Expr (See #4)