### PR TITLE
Implement Type System

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -19,12 +19,26 @@ macro_rules! ref_unwrap {
 macro_rules! perform_op {
     ($dest: expr, $reg1:expr, $reg2:expr, $typ:expr, $op:tt) => {
         match $typ {
-            Type::I32 => unsafe { ($dest.i32 = $reg1.i32 $op $reg2.i32) },
-            Type::I64 => unsafe { ($dest.i64 = $reg1.i64 $op $reg2.i64) },
-            Type::U32 => unsafe { ($dest.u32 = $reg1.u32 $op $reg2.u32) },
-            Type::U64 => unsafe { ($dest.u64 = $reg1.u64 $op $reg2.u64) },
-            Type::F32 => unsafe { ($dest.f32 = $reg1.f32 $op $reg2.f32) },
-            Type::F64 => unsafe { ($dest.f64 = $reg1.f64 $op $reg2.f64) },
+            Type::I32 => unsafe { $dest.i32 = $reg1.i32 $op $reg2.i32 },
+            Type::I64 => unsafe { $dest.i64 = $reg1.i64 $op $reg2.i64 },
+            Type::U32 => unsafe { $dest.u32 = $reg1.u32 $op $reg2.u32 },
+            Type::U64 => unsafe { $dest.u64 = $reg1.u64 $op $reg2.u64 },
+            Type::F32 => unsafe { $dest.f32 = $reg1.f32 $op $reg2.f32 },
+            Type::F64 => unsafe { $dest.f64 = $reg1.f64 $op $reg2.f64 },
+            _ => todo!()
+        }
+    };
+}
+
+macro_rules! perform_cmp {
+    ($reg1:expr, $reg2:expr, $typ:expr, $op:tt) => {
+        match $typ {
+            Type::I32 => unsafe { $reg1.i32 $op $reg2.i32 },
+            Type::I64 => unsafe { $reg1.i64 $op $reg2.i64 },
+            Type::U32 => unsafe { $reg1.u32 $op $reg2.u32 },
+            Type::U64 => unsafe { $reg1.u64 $op $reg2.u64 },
+            Type::F32 => unsafe { $reg1.f32 $op $reg2.f32 },
+            Type::F64 => unsafe { $reg1.f64 $op $reg2.f64 },
             _ => todo!()
         }
     };
@@ -975,13 +989,12 @@ impl Generator {
                     perform_op!(self.registers[*dest], v1, v2, typ, /);
                 }
                 Instruction::Cmp { dest, src, typ } => {
-                    todo!()
-                    // let lhs = self.registers[*dest];
-                    // let rhs = self.registers[*src];
-                    // flags = 0;
-                    // flags |= (lhs == rhs) as usize * EQ;
-                    // flags |= (lhs < rhs) as usize * LT;
-                    // flags |= (lhs > rhs) as usize * GT;
+                    let v1 = self.registers[*dest];
+                    let v2 = self.registers[*src];
+                    flags = 0;
+                    flags |= perform_cmp!(v1, v2, typ, ==) as usize * EQ;
+                    flags |= perform_cmp!(v1, v2, typ, <) as usize * LT;
+                    flags |= perform_cmp!(v1, v2, typ, >) as usize * GT;
                     // >= is flags & EQ || flags & GT
                     // <= is flags & EQ || flags & LT
                     // != is not flags & EQ

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -6,6 +6,7 @@ use crate::lexer::{Token, TokenType, Location};
 use crate::parser::{Tree, TreeType};
 
 pub const ERR_STR: &str = "\x1b[91merror\x1b[0m";
+pub const WARN_STR: &str = "\x1b[93mwarning\x1b[0m";
 
 macro_rules! ref_unwrap {
     ($str:expr) => {
@@ -697,6 +698,9 @@ impl Generator {
         assert!(expr_children.len() == 1, "Expected {{Expr}}");
         let expr = &expr_children[0];
         self.convert_expr(expr)?;
+        println!("{}: Could not resolve type for StmtExpr. Defaulting to `I32`.", WARN_STR);
+        todo!();
+        self.resolve_types(Type::I32);
         self.reset_registers();
         Ok(())
     }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
-use crate::lexer::{Token, TokenType, Location};
+use crate::lexer::{Location, Token, TokenType};
 use crate::parser::{Tree, TreeType};
 
 pub const ERR_STR: &str = "\x1b[91merror\x1b[0m";
@@ -50,13 +50,10 @@ macro_rules! parse_type {
     ($parse_typ:ty, $loc:expr, $val:expr, $typ: expr) => {
         match $val.parse::<$parse_typ>() {
             Ok(val) => Ok(val),
-            Err(e) => Err(
-                format!("{}: {:?}: Integer Literal `{}` too big for Type `{:?}`",
-                ERR_STR,
-                $loc,
-                $val,
-                $typ)
-            )
+            Err(e) => Err(format!(
+                "{}: {:?}: Integer Literal `{}` too big for Type `{:?}`",
+                ERR_STR, $loc, $val, $typ
+            )),
         }
     };
 }
@@ -78,7 +75,7 @@ impl std::fmt::Display for Memory {
 }
 
 impl std::fmt::Debug for Memory {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> { 
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{}", unsafe { self.u64 })
     }
 }
@@ -104,31 +101,102 @@ struct Variable {
 
 #[derive(Debug, PartialEq)]
 enum Instruction {
-    LoadUnknown { dest: usize, val: String, loc: Location },
-    LoadI32 { dest: usize, val: i32 },
-    LoadI64 { dest: usize, val: i64 },
-    LoadU32 { dest: usize, val: u32 },
-    LoadU64 { dest: usize, val: u64 },
-    LoadF32 { dest: usize, val: f32 },
-    LoadF64 { dest: usize, val: f64 },
-    Add { dest: usize, src: usize, typ: Type },
-    Sub { dest: usize, src: usize, typ: Type },
-    Mul { dest: usize, src: usize, typ: Type },
-    Div { dest: usize, src: usize, typ: Type },
-    Cmp { dest: usize, src: usize, typ: Type },
-    Jmp { dest: usize },
-    JmpEq { dest: usize },
-    JmpNeq { dest: usize },
-    JmpGt { dest: usize },
-    JmpGte { dest: usize },
-    JmpLt { dest: usize },
-    JmpLte { dest: usize },
-    Move { dest: usize, src: usize },
-    LoadMem { reg: usize, var: Variable },
-    StoreMem { reg: usize, var: Variable },
-    Call { fn_name: String },
-    Push { reg: usize },
-    Pop { reg: usize },
+    LoadUnknown {
+        dest: usize,
+        val: String,
+        loc: Location,
+    },
+    LoadI32 {
+        dest: usize,
+        val: i32,
+    },
+    LoadI64 {
+        dest: usize,
+        val: i64,
+    },
+    LoadU32 {
+        dest: usize,
+        val: u32,
+    },
+    LoadU64 {
+        dest: usize,
+        val: u64,
+    },
+    LoadF32 {
+        dest: usize,
+        val: f32,
+    },
+    LoadF64 {
+        dest: usize,
+        val: f64,
+    },
+    Add {
+        dest: usize,
+        src: usize,
+        typ: Type,
+    },
+    Sub {
+        dest: usize,
+        src: usize,
+        typ: Type,
+    },
+    Mul {
+        dest: usize,
+        src: usize,
+        typ: Type,
+    },
+    Div {
+        dest: usize,
+        src: usize,
+        typ: Type,
+    },
+    Cmp {
+        dest: usize,
+        src: usize,
+        typ: Type,
+    },
+    Jmp {
+        dest: usize,
+    },
+    JmpEq {
+        dest: usize,
+    },
+    JmpNeq {
+        dest: usize,
+    },
+    JmpGt {
+        dest: usize,
+    },
+    JmpGte {
+        dest: usize,
+    },
+    JmpLt {
+        dest: usize,
+    },
+    JmpLte {
+        dest: usize,
+    },
+    Move {
+        dest: usize,
+        src: usize,
+    },
+    LoadMem {
+        reg: usize,
+        var: Variable,
+    },
+    StoreMem {
+        reg: usize,
+        var: Variable,
+    },
+    Call {
+        fn_name: String,
+    },
+    Push {
+        reg: usize,
+    },
+    Pop {
+        reg: usize,
+    },
     Return {},
     // Print { src: usize },
 }
@@ -193,14 +261,23 @@ impl Function {
 
     fn add_local_variable(&mut self, var_name: String, mem: usize, scope_depth: usize, typ: &Type) {
         let mut scope_var = self.local_variables.get_mut(scope_depth).unwrap();
-        scope_var.insert(var_name, Variable {mem, typ: typ.clone() });
+        scope_var.insert(
+            var_name,
+            Variable {
+                mem,
+                typ: typ.clone(),
+            },
+        );
         self.stack_size += 1;
         // self.local_variables.insert(var_name, mem);
     }
 
     fn add_param(&mut self, param_name: &str, typ: &Type) -> Variable {
         let mem = self.get_stack_size();
-        let var = Variable {mem, typ: typ.clone() };
+        let var = Variable {
+            mem,
+            typ: typ.clone(),
+        };
         self.param_variables.insert(param_name.to_owned(), var);
         self.stack_size += 1;
         var
@@ -243,7 +320,7 @@ impl Generator {
     pub fn new(ast: Tree) -> Result<Self, String> {
         let mut gen = Self {
             ast,
-            registers: vec![Memory { u64: 0} ; 100],
+            registers: vec![Memory { u64: 0 }; 100],
             register_ctr: 0,
             functions: HashMap::new(),
             code: vec![],
@@ -290,7 +367,7 @@ impl Generator {
     fn get_register(&mut self) -> usize {
         let r = self.register_ctr;
         if r >= self.registers.len() {
-            self.registers.push( Memory { u64: 0 });
+            self.registers.push(Memory { u64: 0 });
         }
         self.register_ctr += 1;
         r
@@ -351,9 +428,9 @@ impl Generator {
                         self.unresolved_typ_instr.push_back(self.code.len());
                         self.code.push(Instruction::LoadUnknown { dest, val, loc });
                     }
-                    _ => todo!()
+                    _ => todo!(),
                 };
-                Ok(Variable {mem: dest, typ })
+                Ok(Variable { mem: dest, typ })
             }
             TreeType::ExprParen => {
                 assert!(instr_children.len() == 1, "Expected {{Expr}}");
@@ -375,7 +452,7 @@ impl Generator {
                     (Type::Unknown, other_type) | (other_type, Type::Unknown) => {
                         self.resolve_types(other_type);
                         other_type
-                    },
+                    }
                     (left_type, right_type) => {
                         if right_type != left_type {
                             return Err(
@@ -384,14 +461,16 @@ impl Generator {
                                 ref_unwrap!(op.tkn).get_loc(),
                                 ref_unwrap!(op.tkn).get_value(),
                                 left_type,
-                                right_type))
+                                right_type));
                         }
                         right_type
                     }
                 };
                 let dest = dest.mem;
                 let src = src.mem;
-                if typ == Type::Unknown { self.unresolved_typ_instr.push_back(self.code.len()) }
+                if typ == Type::Unknown {
+                    self.unresolved_typ_instr.push_back(self.code.len())
+                }
                 match ref_unwrap!(op.tkn, "Expected valid ExprBinary operator, got None instead. This might be a bug in parsing.").get_type() {
                     TokenType::Plus => self.code.push(Instruction::Add { dest, src, typ }),
                     TokenType::Minus => self.code.push(Instruction::Sub { dest, src, typ }),
@@ -449,9 +528,15 @@ impl Generator {
                     Some(var) => {
                         self.code.push(Instruction::LoadMem {
                             reg,
-                            var: Variable { typ: var.typ, mem: var.mem }
+                            var: Variable {
+                                typ: var.typ,
+                                mem: var.mem,
+                            },
                         });
-                        Ok(Variable {mem: reg, typ: var.typ })
+                        Ok(Variable {
+                            mem: reg,
+                            typ: var.typ,
+                        })
                     }
                     None => Err(format!(
                         "{}: {:?}: Undefined variable `{}`",
@@ -493,7 +578,10 @@ impl Generator {
                                 reg.typ)
                             );
                         }
-                        self.code.push(Instruction::Move { dest: reg_ctr, src: reg.mem });
+                        self.code.push(Instruction::Move {
+                            dest: reg_ctr,
+                            src: reg.mem,
+                        });
                     }
                     self.code.push(Instruction::Call { fn_name });
                     let reg = self.get_register();
@@ -503,7 +591,10 @@ impl Generator {
                     for reg in (0..curr_reg_ctr).rev() {
                         self.code.push(Instruction::Pop { reg });
                     }
-                    Ok( Variable { typ: fn_return_type, mem: reg } )
+                    Ok(Variable {
+                        typ: fn_return_type,
+                        mem: reg,
+                    })
                 } else {
                     Err(format!(
                         "{} {:?}: Unknown function `{}`",
@@ -606,16 +697,24 @@ impl Generator {
                 Type::Unknown => {
                     self.resolve_types(expected_type)?;
                 }
-                _ => return Err(
-                        format!("{}: {:?}: Type mismatch! Expected type `{:?}`, got type `{:?}`.",
+                _ => {
+                    return Err(format!(
+                        "{}: {:?}: Type mismatch! Expected type `{:?}`, got type `{:?}`.",
                         ERR_STR,
                         let_name.get_loc(),
                         expected_type,
-                        reg.typ)
-                )
+                        reg.typ
+                    ))
+                }
             };
         }
-        self.code.push(Instruction::StoreMem { reg: reg.mem, var: Variable { typ: expected_type, mem } });
+        self.code.push(Instruction::StoreMem {
+            reg: reg.mem,
+            var: Variable {
+                typ: expected_type,
+                mem,
+            },
+        });
         self.reset_registers();
         Ok(())
         // self.code.push(Instruction::StoreMem { reg, mem, typ: Type::U64 });
@@ -651,16 +750,18 @@ impl Generator {
         match (var.typ, reg.typ) {
             (Type::Unknown, Type::Unknown) => panic!(),
             (Type::Unknown, _) => todo!(),
-            (typ, Type::Unknown) => { self.resolve_types(typ)?; },
+            (typ, Type::Unknown) => {
+                self.resolve_types(typ)?;
+            }
             (var_typ, expr_typ) => {
                 if var_typ != expr_typ {
-                    return Err(
-                        format!("{}: {:?}: Type mismatch! Expected type `{:?}`, got type `{:?}`.",
+                    return Err(format!(
+                        "{}: {:?}: Type mismatch! Expected type `{:?}`, got type `{:?}`.",
                         ERR_STR,
                         ref_unwrap!(assign_name.tkn).get_loc(),
                         var.typ,
-                        reg.typ)
-                );
+                        reg.typ
+                    ));
                 }
             }
         }
@@ -710,10 +811,17 @@ impl Generator {
     fn convert_stmt_return(&mut self, ret_tree: &Tree) -> Result<(), String> {
         let child_count = ret_tree.children.len();
         assert!(&[1, 2].contains(&child_count));
-        self.functions.get_mut(&self.current_fn).unwrap().return_found = true;
+        self.functions
+            .get_mut(&self.current_fn)
+            .unwrap()
+            .return_found = true;
         if child_count == 2 {
             let reg = self.convert_expr(&ret_tree.children[1])?;
-            let fn_return_type = self.functions.get(&self.current_fn).unwrap().get_return_type();
+            let fn_return_type = self
+                .functions
+                .get(&self.current_fn)
+                .unwrap()
+                .get_return_type();
             match (fn_return_type, reg.typ) {
                 (Type::None, _) => {
                     return Err(
@@ -724,20 +832,18 @@ impl Generator {
                         reg.typ
                         )
                     );
-                },
+                }
                 (ret_type, expr_type) => {
                     if expr_type == Type::Unknown {
                         self.resolve_types(ret_type);
                     } else if expr_type != ret_type {
-                        return Err(
-                            format!(
+                        return Err(format!(
                             "{}: {:?}: Function is declared to return `{:?}`, but found `{:?}`.",
                             ERR_STR,
                             ref_unwrap!(ret_tree.children[0].tkn).get_loc(),
                             ret_type,
                             expr_type
-                            )
-                        );
+                        ));
                     }
                 }
             }
@@ -792,45 +898,81 @@ impl Generator {
 
     fn set_load_instr(&mut self, index: usize, typ: Type) -> Result<(), String> {
         self.code[index] = match &self.code[index] {
-            Instruction::LoadUnknown { dest, val, loc } => {
-                match typ {
-                    Type::I32 => {
-                        let val = parse_type!(i32, *loc, *val, typ)?;
-                        Instruction::LoadI32 { dest: *dest, val }
-                    }
-                    Type::I64 => {
-                        let val = parse_type!(i64, loc, val, typ)?;
-                        Instruction::LoadI64 { dest: *dest, val }
-                    }
-                    Type::U32 => {
-                        let val = parse_type!(u32, loc, val, typ)?;
-                        Instruction::LoadU32 { dest: *dest, val }
-                    }
-                    Type::U64 => {
-                        let val = parse_type!(u64, loc, val, typ)?;
-                        Instruction::LoadU64 { dest: *dest, val }
-                    }
-                    _ => todo!()
+            Instruction::LoadUnknown { dest, val, loc } => match typ {
+                Type::I32 => {
+                    let val = parse_type!(i32, *loc, *val, typ)?;
+                    Instruction::LoadI32 { dest: *dest, val }
                 }
+                Type::I64 => {
+                    let val = parse_type!(i64, loc, val, typ)?;
+                    Instruction::LoadI64 { dest: *dest, val }
+                }
+                Type::U32 => {
+                    let val = parse_type!(u32, loc, val, typ)?;
+                    Instruction::LoadU32 { dest: *dest, val }
+                }
+                Type::U64 => {
+                    let val = parse_type!(u64, loc, val, typ)?;
+                    Instruction::LoadU64 { dest: *dest, val }
+                }
+                _ => todo!(),
             },
-            Instruction::Add { dest, src, typ: _typ } =>
-                Instruction::Add { dest: *dest, src: *src, typ },
-            Instruction::Sub { dest, src, typ: _typ } =>
-                Instruction::Sub { dest: *dest, src: *src, typ },
-            Instruction::Mul { dest, src, typ: _typ } =>
-                Instruction::Mul { dest: *dest, src: *src, typ },
-            Instruction::Div { dest, src, typ: _typ } =>
-                Instruction::Div { dest: *dest, src: *src, typ },
-            Instruction::Cmp { dest, src, typ: _typ } =>
-                Instruction::Cmp { dest: *dest, src: *src, typ },
-            e => todo!("Handle Instruction {:?}", e)
+            Instruction::Add {
+                dest,
+                src,
+                typ: _typ,
+            } => Instruction::Add {
+                dest: *dest,
+                src: *src,
+                typ,
+            },
+            Instruction::Sub {
+                dest,
+                src,
+                typ: _typ,
+            } => Instruction::Sub {
+                dest: *dest,
+                src: *src,
+                typ,
+            },
+            Instruction::Mul {
+                dest,
+                src,
+                typ: _typ,
+            } => Instruction::Mul {
+                dest: *dest,
+                src: *src,
+                typ,
+            },
+            Instruction::Div {
+                dest,
+                src,
+                typ: _typ,
+            } => Instruction::Div {
+                dest: *dest,
+                src: *src,
+                typ,
+            },
+            Instruction::Cmp {
+                dest,
+                src,
+                typ: _typ,
+            } => Instruction::Cmp {
+                dest: *dest,
+                src: *src,
+                typ,
+            },
+            e => todo!("Handle Instruction {:?}", e),
         };
         Ok(())
     }
 
     fn convert_fn(&mut self, func: &Tree) -> Result<(), String> {
         let fn_children = &func.children;
-        assert!(&[4, 5].contains(&fn_children.len()), "fnKeyword fnName {{Param}} [ReturnType] {{Block}} expected.");
+        assert!(
+            &[4, 5].contains(&fn_children.len()),
+            "fnKeyword fnName {{Param}} [ReturnType] {{Block}} expected."
+        );
         let fn_keyword = ref_unwrap!(fn_children[0].tkn);
         assert!(fn_keyword.get_type() == TokenType::FnKeyword);
         let fn_name = ref_unwrap!(fn_children[1].tkn);
@@ -851,28 +993,32 @@ impl Generator {
         if fn_children.len() == 4 {
             self.convert_block(&fn_children[3])?;
         } else if fn_children.len() == 5 {
-            let fn_return =&fn_children[3];
+            let fn_return = &fn_children[3];
             assert!(*ref_unwrap!(fn_return.typ) == TreeType::TypeDecl);
             let return_children = &fn_return.children;
             assert!(return_children.len() == 2);
-            
+
             let type_arrow = &return_children[0];
             assert!(ref_unwrap!(type_arrow.tkn).get_type() == TokenType::Arrow);
-            
+
             let type_name = &return_children[1];
             assert!(ref_unwrap!(type_name.tkn).get_type() == TokenType::Name);
-            
+
             let type_name_str = ref_unwrap!(type_name.tkn).get_value();
-            
+
             let typ = match self.convert_type_str(&type_name_str) {
                 Ok(t) => t,
-                Err(e) => return Err(format!("{}: {:?}: {}",
-                ERR_STR,
-                ref_unwrap!(type_name.tkn).get_loc(),
-                e))
+                Err(e) => {
+                    return Err(format!(
+                        "{}: {:?}: {}",
+                        ERR_STR,
+                        ref_unwrap!(type_name.tkn).get_loc(),
+                        e
+                    ))
+                }
             };
             self.functions.get_mut(&name).unwrap().set_return_type(&typ);
-            
+
             self.convert_block(&fn_children[4])?;
         }
         let return_found = self.functions.get(&self.current_fn).unwrap().return_found;
@@ -880,18 +1026,21 @@ impl Generator {
         match (return_found, return_type) {
             (_, Type::None) => {
                 if !(*self.code.last().unwrap() == Instruction::Return {}) {
-                    println!("{}: Inserting Return instruction in {}", WARN_STR, self.current_fn);
+                    println!(
+                        "{}: Inserting Return instruction in {}",
+                        WARN_STR, self.current_fn
+                    );
                     self.code.push(Instruction::Return {});
                 }
-            },
+            }
             (false, t) => {
                 return Err(
                     format!("{}: Function `{}` is declared to return `{:?}`, but no return statements found.",
-                    ERR_STR, 
+                    ERR_STR,
                     self.current_fn,
                     t)
                 );
-            },
+            }
             (true, t) => {
                 if !(*self.code.last().unwrap() == Instruction::Return {}) {
                     return Err(
@@ -899,7 +1048,7 @@ impl Generator {
                         ERR_STR,
                         fn_name.get_loc(),
                         self.current_fn,
-                        t))
+                        t));
                 }
             }
         }
@@ -919,7 +1068,7 @@ impl Generator {
                             assert!(p.children.len() == 2);
                             let param_node = &p.children[0];
                             let param_name = ref_unwrap!(param_node.tkn).get_value();
-                            
+
                             let param_type = ref_unwrap!(&p.children[1].typ);
                             assert!(*param_type == TreeType::TypeDecl);
                             let param_type_child = &p.children[1].children;
@@ -932,10 +1081,14 @@ impl Generator {
 
                             let typ = match self.convert_type_str(&type_name_str) {
                                 Ok(t) => t,
-                                Err(e) => return Err(format!("{}: {:?}: {}",
+                                Err(e) => {
+                                    return Err(format!(
+                                        "{}: {:?}: {}",
                                         ERR_STR,
                                         ref_unwrap!(type_name.tkn).get_loc(),
-                                        e))
+                                        e
+                                    ))
+                                }
                             };
 
                             let local_lookup = self.functions.get_mut(&self.current_fn).expect("At this point, function table is guaranteed to contain current_fn.");
@@ -948,10 +1101,7 @@ impl Generator {
                                 ));
                             }
                             let var = local_lookup.add_param(&param_name, &typ);
-                            self.code.push(Instruction::StoreMem {
-                                reg: reg_ctr,
-                                var,
-                            });
+                            self.code.push(Instruction::StoreMem { reg: reg_ctr, var });
                             reg_ctr += 1;
                         }
                         _ => {
@@ -1052,9 +1202,9 @@ impl Generator {
 
         let mut return_stack = VecDeque::<usize>::new();
         let mut return_values = VecDeque::<Memory>::new();
-        let mut stack = vec![Memory { u64: 0} ; STACK_SIZE];
+        let mut stack = vec![Memory { u64: 0 }; STACK_SIZE];
         let mut stack_ptr = STACK_SIZE - 1 - self.get_function_stack_size(&entry_point);
-        
+
         let mut flags = 0;
         const EQ: usize = 1;
         const LT: usize = 2;
@@ -1081,22 +1231,22 @@ impl Generator {
                 Instruction::LoadUnknown { .. } => panic!(),
                 Instruction::LoadI32 { dest, val } => {
                     self.registers[*dest].i32 = *val;
-                },
+                }
                 Instruction::LoadI64 { dest, val } => {
                     self.registers[*dest].i64 = *val;
-                },
+                }
                 Instruction::LoadU32 { dest, val } => {
-                    self.registers[*dest].u32  = *val;
-                },
+                    self.registers[*dest].u32 = *val;
+                }
                 Instruction::LoadU64 { dest, val } => {
-                    self.registers[*dest].u64  = *val;
-                },
+                    self.registers[*dest].u64 = *val;
+                }
                 Instruction::LoadF32 { dest, val } => {
                     todo!()
-                },
+                }
                 Instruction::LoadF64 { dest, val } => {
                     todo!()
-                },
+                }
                 Instruction::Add { dest, src, typ } => {
                     let v1 = self.registers[*dest];
                     let v2 = self.registers[*src];
@@ -1171,10 +1321,16 @@ impl Generator {
                 Instruction::Move { dest, src } => {
                     self.registers[*dest] = self.registers[*src];
                 }
-                Instruction::LoadMem { reg, var: Variable { typ, mem } } => {
+                Instruction::LoadMem {
+                    reg,
+                    var: Variable { typ, mem },
+                } => {
                     self.registers[*reg] = stack[stack_ptr + *mem + 1];
                 }
-                Instruction::StoreMem { reg, var: Variable { typ, mem } } => {
+                Instruction::StoreMem {
+                    reg,
+                    var: Variable { typ, mem },
+                } => {
                     stack[stack_ptr + *mem + 1] = self.registers[*reg];
                 }
                 Instruction::Call { fn_name } => {

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -1,6 +1,6 @@
-File: Fn*;
+File = Fn*;
 
-Fn = "func" "name" ParamList ["->" ReturnType] Block;
+Fn = "func" "name" ParamList ["->" "type"] Block;
 
 Param = "name" TypeDecl [","];
 ParamList = "(" {Param} ")";
@@ -16,10 +16,9 @@ Stmt = StmtExpr
 StmtExpr = Expr ";";
 StmtLet = "let" "name" TypeDecl "=" Expr ";";
 StmtAssign = "name" "=" Expr ";";
-StmtIf = "if" "(" Expr ")" Block {"else" Block};
+StmtIf = "if" "(" Expr ")" Block ["else" Block];
 StmtReturn = "return" [Expr] ";";
 
-ReturnType = "type";
 TypeDecl = ":" "type";
 
 Arg = Expr [","];

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -14,10 +14,12 @@ Stmt = StmtExpr
      | StmtReturn;
 
 StmtExpr = Expr ";";
-StmtLet = "let" "name" "=" Expr ";";
+StmtLet = "let" "name" TypeDecl "=" Expr ";";
 StmtAssign = "name" "=" Expr ";";
 StmtIf = "if" "(" Expr ")" Block {"else" Block};
 StmtReturn = "return" [Expr] ";";
+
+TypeDecl = ":" "type";
 
 Arg = Expr [","];
 ArgList = "(" {Arg} ")";

--- a/src/grammar.ebnf
+++ b/src/grammar.ebnf
@@ -1,8 +1,8 @@
 File: Fn*;
 
-Fn = "func" "name" ParamList Block;
+Fn = "func" "name" ParamList ["->" ReturnType] Block;
 
-Param = "name" [","];
+Param = "name" TypeDecl [","];
 ParamList = "(" {Param} ")";
 
 Block = "{" {Stmt} "}";
@@ -19,6 +19,7 @@ StmtAssign = "name" "=" Expr ";";
 StmtIf = "if" "(" Expr ")" Block {"else" Block};
 StmtReturn = "return" [Expr] ";";
 
+ReturnType = "type";
 TypeDecl = ":" "type";
 
 Arg = Expr [","];

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -15,6 +15,7 @@ pub enum TokenType {
     IfKeyword,
     ElseKeyword,
     ReturnKeyword,
+    TypeDecl,
     Equal,
     Plus,
     Minus,
@@ -32,7 +33,7 @@ pub enum TokenType {
     Eof,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Location {
     file: String,
     row: usize,
@@ -137,7 +138,7 @@ impl Lexer {
     fn next_token(&mut self) -> Result<Token, String> {
         assert_eq!(
             TokenType::Eof as u8 + 1,
-            25,
+            26,
             "Not all TokenTypes are handled in next_token()"
         );
         let c = self.next_char()?;
@@ -145,7 +146,7 @@ impl Lexer {
             '0'..='9' => {
                 let mut value = String::from(c);
                 while let Ok(nc) = self.next_char() {
-                    if !nc.is_ascii_digit() {
+                    if !nc.is_alphanumeric() {
                         self.current_char -= 1; // Went too far, go a step back
                         break;
                     }
@@ -287,6 +288,11 @@ impl Lexer {
                     loc: self.get_location(),
                 })
             }
+            ':' => Ok(Token {
+                typ: TokenType::TypeDecl,
+                value: String::from(c),
+                loc: self.get_location(),
+            }),
             '+' => Ok(Token {
                 typ: TokenType::Plus,
                 value: String::from(c),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -16,6 +16,7 @@ pub enum TokenType {
     ElseKeyword,
     ReturnKeyword,
     TypeDecl,
+    Arrow,
     Equal,
     Plus,
     Minus,
@@ -138,7 +139,7 @@ impl Lexer {
     fn next_token(&mut self) -> Result<Token, String> {
         assert_eq!(
             TokenType::Eof as u8 + 1,
-            26,
+            27,
             "Not all TokenTypes are handled in next_token()"
         );
         let c = self.next_char()?;
@@ -298,11 +299,24 @@ impl Lexer {
                 value: String::from(c),
                 loc: self.get_location(),
             }),
-            '-' => Ok(Token {
-                typ: TokenType::Minus,
-                value: String::from(c),
-                loc: self.get_location(),
-            }),
+            '-' => {
+                let (typ, value) = if let Ok(nc) = self.next_char() {
+                    match nc {
+                        '>' => (TokenType::Arrow, String::from("->")),
+                        _ => {
+                            self.current_char -= 1; // Went too far, go a step back
+                            (TokenType::Minus, String::from("-"))
+                        }
+                    }
+                } else {
+                    (TokenType::Minus, String::from("-"))
+                };
+                Ok(Token {
+                    typ,
+                    value,
+                    loc: self.get_location(),
+                })
+            }
             '*' => Ok(Token {
                 typ: TokenType::Mult,
                 value: String::from(c),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,6 +23,7 @@ pub enum TreeType {
     ExprBinary,
     ExprParen,
     ExprCall,
+    TypeDecl,
 }
 
 #[derive(Debug, Clone)]
@@ -236,11 +237,20 @@ impl Parser {
         self.parse_expr_rec(TokenType::Eof)
     }
 
+    fn parse_type_decl(&mut self) -> Result<(), String> {
+        let m = self.open();
+        self.expect(TokenType::TypeDecl)?;
+        self.expect(TokenType::Name)?;
+        self.close(m, TreeType::TypeDecl);
+        Ok(())
+    }
+
     fn parse_stmt_let(&mut self) -> Result<(), String> {
         assert!(self.at(TokenType::LetKeyword));
         let m = self.open();
         self.expect(TokenType::LetKeyword)?;
         self.expect(TokenType::Name)?;
+        self.parse_type_decl()?;
         self.expect(TokenType::Equal)?;
         self.parse_expr()?;
         self.expect(TokenType::Semi)?;
@@ -382,7 +392,7 @@ impl Parser {
     pub fn parse_file(&mut self) -> Result<(), String> {
         assert_eq!(
             TokenType::Eof as u8 + 1,
-            25,
+            26,
             "Not all TokenTypes are handled in parse_file()"
         );
         let m = self.open();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,6 @@ pub enum TreeType {
     Func,
     ParamList,
     Param,
-    ReturnType,
     ArgList,
     Arg,
     Block,
@@ -385,7 +384,7 @@ impl Parser {
         let m = self.open();
         self.expect(TokenType::Arrow)?;
         self.expect(TokenType::Name)?;
-        self.close(m, TreeType::ReturnType);
+        self.close(m, TreeType::TypeDecl);
         Ok(())
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,6 +10,7 @@ pub enum TreeType {
     Func,
     ParamList,
     Param,
+    ReturnType,
     ArgList,
     Arg,
     Block,
@@ -360,6 +361,7 @@ impl Parser {
     fn parse_param(&mut self) -> Result<(), String> {
         let m = self.open();
         self.expect(TokenType::Name)?;
+        self.parse_type_decl()?;
         if self.at(TokenType::Comma) {
             self.advance();
         }
@@ -378,12 +380,24 @@ impl Parser {
         Ok(())
     }
 
+    fn parse_return_type(&mut self) -> Result<(), String> {
+        assert!(self.at(TokenType::Arrow));
+        let m = self.open();
+        self.expect(TokenType::Arrow)?;
+        self.expect(TokenType::Name)?;
+        self.close(m, TreeType::ReturnType);
+        Ok(())
+    }
+
     fn parse_func(&mut self) -> Result<(), String> {
         assert!(self.at(TokenType::FnKeyword));
         let m = self.open();
         self.expect(TokenType::FnKeyword)?;
         self.expect(TokenType::Name)?;
         self.parse_param_list()?;
+        if self.at(TokenType::Arrow) {
+            self.parse_return_type()?;
+        }
         self.parse_block()?;
         self.close(m, TreeType::Func);
         Ok(())
@@ -392,7 +406,7 @@ impl Parser {
     pub fn parse_file(&mut self) -> Result<(), String> {
         assert_eq!(
             TokenType::Eof as u8 + 1,
-            26,
+            27,
             "Not all TokenTypes are handled in parse_file()"
         );
         let m = self.open();

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,4 +1,5 @@
 func main() {
-    let a: u32 = 7;
-    let b: u32 = a;
+    let i64: u32 = 5;
+    let a: u32 = (0 - 20 + 5) / 5;
+    let b: u32 = a - i64;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -2,4 +2,7 @@ func main() {
     let i64: i32 = 5;
     let a: i32 = (0 - 20 + 5) / 5;
     let b: i32 = a - i64;
+    let c: u64 = 5 * (980123 + 12);
+    let d: u64 = c * 10;
+    let e: u64 = (d - 5) / 10;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,14 +1,4 @@
-func ack(m, n) {
-    if (m == 0) { return n + 1; }
-    if (n == 0) { return ack(m - 1, 1); }
-    return ack(m - 1, ack(m, n - 1));
-}
-
-func factorial(n) {
-    if (n <= 1) { return 1; }
-    return n * factorial(n - 1);
-}
-
 func main() {
-    let a = factorial(ack(factorial(2), factorial(2)));
+    let a: u32 = 7;
+    let b: u32 = a;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,5 +1,5 @@
 func main() {
-    let i64: u32 = 5;
-    let a: u32 = (0 - 20 + 5) / 5;
-    let b: u32 = a - i64;
+    let i64: i32 = 5;
+    let a: i32 = (0 - 20 + 5) / 5;
+    let b: i32 = a - i64;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,7 +1,9 @@
 func main() {
-    let i64: i32 = 5;
-    let a: i32 = (0 - 20 + 5) / 5;
-    let b: i32 = a - i64;
-    let c: u32 = 5;
-    c = b;
+    let a: i32 = 5;
+    let b: u64 = 0;
+    if (a == 4) {
+        b = 5;
+    } else {
+        b = 10;
+    }
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,9 +1,20 @@
+func ack(m: u32, n: u64) -> u64 {
+    if (m == 0) { return n + 1; }
+    if (n == 0) { return ack(m - 1, 1); }
+    return ack(m - 1, ack(m, n - 1));
+}
+
+func factorial(n: u64) -> u64 {
+    if (n <= 1) { return 1; }
+    return n * factorial(n - 1);
+}
+
 func main() {
-    let a: i32 = 5;
-    let b: u64 = 0;
-    if (a == 4) {
-        b = 5;
+    let result: u64 = ack(3, 3);
+    if (result > 100) {
+        let a: i32 = 10;
     } else {
-        b = 10;
+        let a: u32 = 5;
     }
+    return;
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -2,7 +2,6 @@ func main() {
     let i64: i32 = 5;
     let a: i32 = (0 - 20 + 5) / 5;
     let b: i32 = a - i64;
-    let c: u64 = 5 * (980123 + 12);
-    let d: u64 = c * 10;
-    let e: u64 = (d - 5) / 10;
+    let c: u32 = 5;
+    c = b;
 }


### PR DESCRIPTION
It's a basic type system. Variables now need a type when they're declared. Reassignments assume the old type. Type inference for literals is a thing (e.g. `let a: i32 = 5;` turns 5 into a `LoadI32`-Instruction), but not quite for variables (e.g. `let a = b;` can't assign/infer the type of `b` onto `a`).

Functions can also have an optional return type, specified by `-> type` after the Parameter Block. If no return type is specified, they're treated as `Type::None` and can crash compilation when expressions like `5 + foo()` are encountered (can't add `Type::None` to anything).

Functions that return values can be called in statements without assigning them to variables, there's no dead-code-elimination or warnings for that yet.