### PR TITLE
Reimplement Codegen

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -26,6 +26,18 @@ pub enum Type {
     F64,
 }
 
+impl Type {
+    pub fn size(&self) -> usize {
+        match self {
+            Type::Arr(t, size) => t.size() * size.iter().product::<usize>(),
+            Type::I32 | Type::U32 => 4,
+            Type::I64 | Type::U64 | Type::Usize => 8,
+            Type::Class(..) => 8,
+            e => todo!("Figure out size of type {:?} in bytes", e),
+        }
+    }
+}
+
 lazy_static!{
     static ref BUILT_IN_FUNC: HashMap<String, TCFunction> = {
         assert!(BUILT_IN_FUNCTIONS.len() == 3);

--- a/src/complicated.bu
+++ b/src/complicated.bu
@@ -1,0 +1,62 @@
+class Test {
+    a: i64;
+    b: Test;
+    c: i64;
+    d: i64;
+    feat new(na: i64, nb: i64, nc: i64) -> Test {
+        this.a = na;
+        // this.b = Test(0, 0, 0);
+        this.c = nc;
+        // this.d gets 0 initialized
+    }
+    func foo(b: i32) -> i64 {
+        return this.d;
+    }
+
+    func fee(b: i32) -> i32 {
+        return b;
+    }
+
+    func faa() {}
+}
+
+class Idee {
+    a: i64;
+    t: Test;
+
+    feat new(na: i64) {
+        this.a = na;
+        this.t = Test(this.a, 5, 10);
+        let a: i64 = this.a;
+        this.t.b.b.b.b.b.b.a = 10;
+    }
+}
+
+func bla(t: Test, t1: Test) -> i64 {
+    return t.d + t1.d;
+}
+
+func retInstance(t: Test) -> Idee {
+    return Idee(t.d);
+}
+
+func main() {
+    let test: Test = Test(2, 3, 4);
+    let idee: Idee = retInstance(test);
+    let e: i32 = 0;
+    let a: u64[3, 3] = [
+         [1 - 3, 2 * 4, 3 / 5],
+         [1 - 3, 2 * 4, 3 / 5],
+         [1 - 3, 2 * 4, 3 / 5],
+    ];
+    let d: i32 = 9;
+    d = 0;
+    test.d = 10;
+    idee.a = 12;
+    let f: i64 = test.foo(5);
+    if (d == 1) {
+
+    } else {
+
+    }
+}

--- a/src/new/compiler.rs
+++ b/src/new/compiler.rs
@@ -43,13 +43,13 @@ impl Compiler {
             println!("Desugaring took {:?}", now.elapsed());
         }
 
-        println!("{:#?}", parsed_ast);
+        // println!("{:#?}", parsed_ast);
         let now = Instant::now();
         self.checker.type_check_file(&mut parsed_ast)?;
         if self.debug {
             println!("Type Checking took {:?}", now.elapsed());
         }
-        println!("{:#?}", parsed_ast);
+        // println!("{:#?}", parsed_ast);
 
         let now = Instant::now();
         self.codegen.generate_code(&parsed_ast)?;

--- a/src/new/compiler.rs
+++ b/src/new/compiler.rs
@@ -16,19 +16,19 @@ pub struct Compiler {
     checker: TypeChecker,
     codegen: Codegen,
     assembler: Assembler,
-    debug: bool,
+    print_debug: bool,
     run: bool
 }
 
 impl Compiler {
-    pub fn new(path: &String, debug: bool, run: bool) -> Result<Self, String> {
+    pub fn new(path: &String, print_debug: bool, run: bool) -> Result<Self, String> {
         Ok(Self {
-            parser: Parser::new().filepath(path)?.debug(debug),
-            desugarer: Desugarer::new().debug(debug),
+            parser: Parser::new().filepath(path)?.debug(print_debug),
+            desugarer: Desugarer::new().debug(print_debug),
             checker: TypeChecker::new(),
-            codegen: Codegen::new().debug(debug),
-            assembler: Assembler::new().debug(debug).filepath(path),
-            debug,
+            codegen: Codegen::new().debug(print_debug),
+            assembler: Assembler::new().debug(print_debug).filepath(path),
+            print_debug,
             run
         })
     }
@@ -36,45 +36,44 @@ impl Compiler {
     pub fn run_everything(&mut self) -> Result<(), String> {
         let now = Instant::now();
         let mut parsed_ast = self.parser.parse_file()?;
-        if self.debug {
+        if self.print_debug {
             println!("Parsing took {:?}", now.elapsed());
         }
 
         let now = Instant::now();
         // self.desugarer.desugar_file(&mut parsed_ast)?;
-        if self.debug {
+        if self.print_debug {
             println!("Desugaring took {:?}", now.elapsed());
         }
 
         // println!("{:#?}", parsed_ast);
         let now = Instant::now();
         self.checker.type_check_file(&mut parsed_ast)?;
-        if self.debug {
+        if self.print_debug {
             println!("Type Checking took {:?}", now.elapsed());
         }
         // println!("{:#?}", parsed_ast);
 
         let now = Instant::now();
         let ir = self.codegen.generate_code(&parsed_ast)?;
-        if self.debug {
+        if self.print_debug {
             println!("Codegen took {:?}", now.elapsed());
         }
         // todo!();
         
         let now = Instant::now();
         self.assembler.generate_x86_64(ir)?;
-        if self.debug {
+        if self.print_debug {
             println!("Assembling took {:?}", now.elapsed());
         }
-        // if self.run {
-        //     let now = Instant::now();
-        //     self.codegen.run()?;
-        //     if self.debug {
-        //         println!("Running took {:?}", now.elapsed());
-        //     }
-        // }
-        Err(String::from("Technically yes, but we're not done yet"))
-        // Ok(())
+        if self.run {
+            let now = Instant::now();
+            self.assembler.run()?;
+            if self.print_debug {
+                println!("Running took {:?}", now.elapsed());
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/new/compiler.rs
+++ b/src/new/compiler.rs
@@ -58,11 +58,11 @@ impl Compiler {
         }
         // todo!();
         
-        // let now = Instant::now();
-        // self.codegen.compile()?;
-        // if self.debug {
-        //     println!("Compiling took {:?}", now.elapsed());
-        // }
+        let now = Instant::now();
+        self.codegen.compile()?;
+        if self.debug {
+            println!("Compiling took {:?}", now.elapsed());
+        }
         // if self.run {
         //     let now = Instant::now();
         //     self.codegen.run()?;

--- a/src/new/compiler.rs
+++ b/src/new/compiler.rs
@@ -8,12 +8,14 @@ use super::new_parser::Parser;
 use super::new_desugar::Desugarer;
 use super::new_checker::TypeChecker;
 use super::new_codegen::Codegen;
+use super::new_assembler::Assembler;
 
 pub struct Compiler {
     parser: Parser,
     desugarer: Desugarer,
     checker: TypeChecker,
     codegen: Codegen,
+    assembler: Assembler,
     debug: bool,
     run: bool
 }
@@ -25,6 +27,7 @@ impl Compiler {
             desugarer: Desugarer::new().debug(debug),
             checker: TypeChecker::new(),
             codegen: Codegen::new().debug(debug),
+            assembler: Assembler::new().debug(debug).filepath(path),
             debug,
             run
         })
@@ -52,16 +55,16 @@ impl Compiler {
         // println!("{:#?}", parsed_ast);
 
         let now = Instant::now();
-        self.codegen.generate_code(&parsed_ast)?;
+        let ir = self.codegen.generate_code(&parsed_ast)?;
         if self.debug {
             println!("Codegen took {:?}", now.elapsed());
         }
         // todo!();
         
         let now = Instant::now();
-        self.codegen.compile()?;
+        self.assembler.generate_x86_64(ir)?;
         if self.debug {
-            println!("Compiling took {:?}", now.elapsed());
+            println!("Assembling took {:?}", now.elapsed());
         }
         // if self.run {
         //     let now = Instant::now();

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -1,3 +1,5 @@
+use super::new_parser::Operation;
+
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum RegMode {
     BIT64,
@@ -109,7 +111,17 @@ pub enum Operand {
     ImmU64(u64),
     ImmI32(i32),
     ImmI64(i64),
+    Cmp(Operation),
     None, // for nodes that do not return any registers
+}
+
+impl IR {
+    pub fn get_lbl(&self) -> String {
+        match &self {
+            Self::Label { name } => name.clone(),
+            _ => unreachable!()
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -31,6 +31,14 @@ pub enum Operand {
     None, // for nodes that do not return any registers
 }
 
+impl Operand {
+    pub const RET: usize = 0;
+    pub const ARG1: usize = 1;
+    pub const ARG2: usize = 2;
+    pub const ARG3: usize = 3;
+    pub const ARG4: usize = 4;
+}
+
 #[derive(Debug)]
 pub enum IR {
     LoadImm { dst: Operand, imm: Operand },

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -33,6 +33,8 @@ pub enum Operand {
 #[derive(Debug)]
 pub enum IR {
     LoadImm { dst: Operand, imm: Operand },
+    StoreStack { offset: Operand, value: Operand },
+    LoadStack { dst: Operand, offset: Operand },
 
     // Arithmetics
     Add { dst: Operand, src1: Operand, src2: Operand },
@@ -53,6 +55,8 @@ pub enum IR {
 
     // Functions
     Call { name: String },
+    AllocStack { bytes: usize },
+    DeallocStack { bytes: usize },
     PushReg,
     PopReg,
     Return,

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -1,0 +1,37 @@
+
+#[derive(Debug)]
+pub enum Operand {
+    Reg(usize),
+    MemOffset(usize), // e.g., stack offset
+    MemAddr(usize),
+    Imm32(u32),
+    Imm64(u64),
+}
+
+#[derive(Debug)]
+pub enum IR {
+    LoadImm { dst: Operand, imm: Operand },
+
+    // Arithmetics
+    Add { dst: Operand, src1: Operand, src2: Operand },
+    Sub { dst: Operand, src1: Operand, src2: Operand },
+    Mul { dst: Operand, src1: Operand, src2: Operand },
+    Div { dst: Operand, src1: Operand, src2: Operand },
+    
+    // Control Flow
+    Label { name: String },
+    Cmp { dst: Operand, src: Operand },
+    Jmp { name: String },
+    JmpEq { name: String },
+    JmpNeq { name: String },
+    JmpLt { name: String },
+    JmpLte { name: String },
+    JmpGt { name: String },
+    JmpGte { name: String },
+
+    // Functions
+    Call { name: String },
+    PushReg,
+    PopReg,
+    Return,
+}

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -73,19 +73,11 @@ impl Register {
     pub const ARG3: Self = Self::R8;  // Third argument in R8
     pub const ARG4: Self = Self::R9;  // Fourth argument in R9
 
-    pub const CALLER_SAVED: [Self; 7] = [
-        Self::RAX,
-        Self::RCX,
-        Self::RDX,
-        Self::R8,
-        Self::R9,
-        Self::R10,
-        Self::R11,
-    ];
-
-    pub const CALLEE_SAVED: [Self; 8] = [
+    // https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#callercallee-saved-registers
+    pub const PRESERVED: [Self; 9] = [
         Self::RBX,
         Self::RBP,
+        Self::RSP,
         Self::RSI,
         Self::RDI,
         Self::R12,
@@ -97,7 +89,13 @@ impl Register {
     pub fn arg(index: usize) -> Self {
         // FIXME: Handle this case
         debug_assert!(index <= 3);
-        Self::from(Self::ARG1 as usize + index)
+        const ARGS: [Register; 4] = [
+            Register::ARG1,
+            Register::ARG2,
+            Register::ARG3,
+            Register::ARG4
+        ];
+        ARGS[index]
     }
 }
 

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum RegMode {
     BIT64,
     BIT32
@@ -21,7 +21,7 @@ impl From<usize> for RegMode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Operand {
     Reg(usize, RegMode),
     StackOffset(usize), // e.g., stack offset

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -140,7 +140,7 @@ pub enum IR {
     Call { name: String },
     AllocStack { bytes: usize },
     DeallocStack { bytes: usize },
-    PushReg,
-    PopReg,
+    PushReg { reg: Register },
+    PopReg { reg: Register },
     Return,
 }

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -1,4 +1,3 @@
-
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum RegMode {
     BIT64,
@@ -22,21 +21,95 @@ impl From<usize> for RegMode {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Register {
+    RAX,
+    RCX,
+    RDX,
+    RBX,
+    RSP,
+    RBP,
+    RSI,
+    RDI,
+    R8,
+    R9,
+    R10,
+    R11,
+    R12,
+    R13,
+    R14,
+    R15,
+    __COUNT,
+}
+
+impl From<usize> for Register {
+    fn from(value: usize) -> Self {
+        match value {
+            0  => Register::RAX,
+            1  => Register::RCX,
+            2  => Register::RDX,
+            3  => Register::RBX,
+            4  => Register::RSP,
+            5  => Register::RBP,
+            6  => Register::RSI,
+            7  => Register::RDI,
+            8  => Register::R8,
+            9  => Register::R9,
+            10 => Register::R10,
+            11 => Register::R11,
+            12 => Register::R12,
+            13 => Register::R13,
+            14 => Register::R14,
+            15 => Register::R15,
+            _ => panic!()
+        }
+    }
+}
+
+impl Register {
+    pub const RET: Self = Self::RAX; // Return value in RAX
+    // We're using the Windows x86-64 convention for arguments:
+    pub const ARG1: Self = Self::RCX; // First argument in RCX
+    pub const ARG2: Self = Self::RDX; // Second argument in RDX
+    pub const ARG3: Self = Self::R8;  // Third argument in R8
+    pub const ARG4: Self = Self::R9;  // Fourth argument in R9
+
+    pub const CALLER_SAVED: [Self; 7] = [
+        Self::RAX,
+        Self::RCX,
+        Self::RDX,
+        Self::R8,
+        Self::R9,
+        Self::R10,
+        Self::R11,
+    ];
+
+    pub const CALLEE_SAVED: [Self; 8] = [
+        Self::RBX,
+        Self::RBP,
+        Self::RSI,
+        Self::RDI,
+        Self::R12,
+        Self::R13,
+        Self::R14,
+        Self::R15,
+    ];
+
+    pub fn arg(index: usize) -> Self {
+        // FIXME: Handle this case
+        debug_assert!(index <= 3);
+        Self::from(Self::ARG1 as usize + index)
+    }
+}
+
+
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Operand {
-    Reg(usize, RegMode),
+    Reg(Register, RegMode),
     StackOffset(usize), // e.g., stack offset
     HeapAddr(usize),
     Imm32(u32),
     Imm64(u64),
     None, // for nodes that do not return any registers
-}
-
-impl Operand {
-    pub const RET: usize = 0;
-    pub const ARG1: usize = 1;
-    pub const ARG2: usize = 2;
-    pub const ARG3: usize = 3;
-    pub const ARG4: usize = 4;
 }
 
 #[derive(Debug)]

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -1,5 +1,5 @@
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum RegMode {
     BIT64,
     BIT32
@@ -21,11 +21,11 @@ impl From<usize> for RegMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Operand {
     Reg(usize, RegMode),
-    MemOffset(usize), // e.g., stack offset
-    MemAddr(usize),
+    StackOffset(usize), // e.g., stack offset
+    HeapAddr(usize),
     Imm32(u32),
     Imm64(u64),
     None, // for nodes that do not return any registers
@@ -34,8 +34,8 @@ pub enum Operand {
 #[derive(Debug)]
 pub enum IR {
     LoadImm { dst: Operand, imm: Operand },
-    StoreStack { offset: Operand, value: Operand },
-    LoadStack { dst: Operand, offset: Operand },
+    Store { addr: Operand, value: Operand },
+    Load { dst: Operand, addr: Operand },
 
     // Arithmetics
     Add { dst: Operand, src1: Operand, src2: Operand },

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -105,8 +105,10 @@ pub enum Operand {
     Reg(Register, RegMode),
     StackOffset(usize), // e.g., stack offset
     HeapAddr(usize),
-    Imm32(u32),
-    Imm64(u64),
+    ImmU32(u32),
+    ImmU64(u64),
+    ImmI32(i32),
+    ImmI64(i64),
     None, // for nodes that do not return any registers
 }
 

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -44,6 +44,7 @@ pub enum IR {
     LoadImm { dst: Operand, imm: Operand },
     Store { addr: Operand, value: Operand },
     Load { dst: Operand, addr: Operand },
+    Move { dst: Operand, src: Operand },
 
     // Arithmetics
     Add { dst: Operand, src1: Operand, src2: Operand },

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -104,7 +104,7 @@ impl Register {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum OperandType {
-    Reg(RegMode),
+    Reg,
     Cmp(Operation),
     ImmU32,
     ImmU64,
@@ -119,6 +119,7 @@ pub struct Operand {
     pub typ: OperandType,
     pub off_or_imm: usize,
     pub reg: Register,
+    pub reg_mode: RegMode,
 }
 
 impl Operand {
@@ -126,14 +127,16 @@ impl Operand {
         Self {
             typ: OperandType::None,
             off_or_imm: 0,
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
     pub fn reg(r: Register, rm: RegMode) -> Self {
         Self {
-            typ: OperandType::Reg(rm),
+            typ: OperandType::Reg,
             off_or_imm: 0,
-            reg: r
+            reg: r,
+            reg_mode: rm
         }
     }
 
@@ -141,42 +144,48 @@ impl Operand {
         Self {
             typ: OperandType::ImmU32,
             off_or_imm: unsafe { std::mem::transmute(immediate as u64) },
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
     pub fn imm_u64(immediate: u64) -> Self {
         Self {
             typ: OperandType::ImmU64,
             off_or_imm: unsafe { std::mem::transmute(immediate) },
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
     pub fn imm_i32(immediate: i32) -> Self {
         Self {
             typ: OperandType::ImmI32,
             off_or_imm: unsafe { std::mem::transmute(immediate as i64) },
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
     pub fn imm_i64(immediate: i64) -> Self {
         Self {
             typ: OperandType::ImmI64,
             off_or_imm: unsafe { std::mem::transmute(immediate) },
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
     pub fn offset(offset: usize) -> Self {
         Self {
             typ: OperandType::Offset,
             off_or_imm: offset,
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
     pub fn cmp(cmp: Operation) -> Self {
         Self {
             typ: OperandType::Cmp(cmp),
             off_or_imm: 0,
-            reg: Register::None
+            reg: Register::None,
+            reg_mode: RegMode::BIT64
         }
     }
 }

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -41,6 +41,7 @@ pub enum Register {
     R14,
     R15,
     __COUNT,
+    None,
 }
 
 impl From<usize> for Register {
@@ -101,18 +102,83 @@ impl Register {
     }
 }
 
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum Operand {
-    Reg(Register, RegMode),
-    StackOffset(usize), // e.g., stack offset
-    HeapAddr(usize),
-    ImmU32(u32),
-    ImmU64(u64),
-    ImmI32(i32),
-    ImmI64(i64),
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum OperandType {
+    Reg(RegMode),
     Cmp(Operation),
-    None, // for nodes that do not return any registers
+    ImmU32,
+    ImmU64,
+    ImmI32,
+    ImmI64,
+    Offset,
+    None // For nodes that do not return anything
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Operand {
+    pub typ: OperandType,
+    pub off_or_imm: usize,
+    pub reg: Register,
+}
+
+impl Operand {
+    pub fn none() -> Self {
+        Self {
+            typ: OperandType::None,
+            off_or_imm: 0,
+            reg: Register::None
+        }
+    }
+    pub fn reg(r: Register, rm: RegMode) -> Self {
+        Self {
+            typ: OperandType::Reg(rm),
+            off_or_imm: 0,
+            reg: r
+        }
+    }
+
+    pub fn imm_u32(immediate: u32) -> Self {
+        Self {
+            typ: OperandType::ImmU32,
+            off_or_imm: unsafe { std::mem::transmute(immediate as u64) },
+            reg: Register::None
+        }
+    }
+    pub fn imm_u64(immediate: u64) -> Self {
+        Self {
+            typ: OperandType::ImmU64,
+            off_or_imm: unsafe { std::mem::transmute(immediate) },
+            reg: Register::None
+        }
+    }
+    pub fn imm_i32(immediate: i32) -> Self {
+        Self {
+            typ: OperandType::ImmI32,
+            off_or_imm: unsafe { std::mem::transmute(immediate as i64) },
+            reg: Register::None
+        }
+    }
+    pub fn imm_i64(immediate: i64) -> Self {
+        Self {
+            typ: OperandType::ImmI64,
+            off_or_imm: unsafe { std::mem::transmute(immediate) },
+            reg: Register::None
+        }
+    }
+    pub fn offset(offset: usize) -> Self {
+        Self {
+            typ: OperandType::Offset,
+            off_or_imm: offset,
+            reg: Register::None
+        }
+    }
+    pub fn cmp(cmp: Operation) -> Self {
+        Self {
+            typ: OperandType::Cmp(cmp),
+            off_or_imm: 0,
+            reg: Register::None
+        }
+    }
 }
 
 impl IR {

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -190,7 +190,7 @@ impl IR {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum IR {
     LoadImm { dst: Operand, imm: Operand },
     Store { addr: Operand, value: Operand },

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -1,7 +1,29 @@
 
 #[derive(Debug)]
+pub enum RegMode {
+    BIT64,
+    BIT32
+}
+
+impl From<&crate::checker::Type> for RegMode {
+    fn from(value: &crate::checker::Type) -> Self {
+        Self::from(value.size())
+    }
+}
+
+impl From<usize> for RegMode {
+    fn from(bytes: usize) -> Self {
+        match bytes {
+            4 => Self::BIT32,
+            8 => Self::BIT64,
+            _ => panic!()
+        }
+    }
+}
+
+#[derive(Debug)]
 pub enum Operand {
-    Reg(usize),
+    Reg(usize, RegMode),
     MemOffset(usize), // e.g., stack offset
     MemAddr(usize),
     Imm32(u32),

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -28,6 +28,7 @@ pub enum Operand {
     MemAddr(usize),
     Imm32(u32),
     Imm64(u64),
+    None, // for nodes that do not return any registers
 }
 
 #[derive(Debug)]

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -134,8 +134,8 @@ pub enum IR {
     // Arithmetics
     Add { dst: Operand, src1: Operand, src2: Operand },
     Sub { dst: Operand, src1: Operand, src2: Operand },
-    Mul { dst: Operand, src1: Operand, src2: Operand },
-    Div { dst: Operand, src1: Operand, src2: Operand },
+    Mul { dst: Operand, src1: Operand, src2: Operand, signed: bool },
+    Div { dst: Operand, src1: Operand, src2: Operand, signed: bool },
     
     // Control Flow
     Label { name: String },

--- a/src/new/instr.rs
+++ b/src/new/instr.rs
@@ -201,6 +201,7 @@ impl IR {
 
 #[derive(Debug, Clone)]
 pub enum IR {
+    // Memory
     LoadImm { dst: Operand, imm: Operand },
     Store { addr: Operand, value: Operand },
     Load { dst: Operand, addr: Operand },

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -1,4 +1,5 @@
 pub mod nodes;
+pub mod instr;
 pub mod new_parser;
 pub mod new_desugar;
 pub mod new_checker;

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -4,4 +4,5 @@ pub mod new_parser;
 pub mod new_desugar;
 pub mod new_checker;
 pub mod new_codegen;
+pub mod new_assembler;
 pub mod compiler;

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -93,6 +93,31 @@ impl Assembler {
                         }
                     }
                 }
+                IR::Sub { dst, src1, src2 } => {
+                    debug_assert!(dst == src1);
+                    debug_assert!(dst.reg != instr::Register::None);
+                    let dst_reg = reg(dst.reg, dst.reg_mode);
+                    match (dst.typ, src2.typ) {
+                        (OperandType::Reg, OperandType::Reg) => {
+                            let src_reg = reg(src2.reg, src2.reg_mode);
+                            push_asm(format!("  sub {dst_reg}, {src_reg}").as_str());
+                        }
+                        (OperandType::Reg, OperandType::Offset) => {
+                            let offset = src2.off_or_imm;
+                            push_asm(format!("  sub {dst_reg}, {offset}").as_str());
+                        }
+                        (OperandType::Reg, OperandType::ImmI32
+                                            | OperandType::ImmI64
+                                            | OperandType::ImmU32
+                                            | OperandType::ImmU64) => {
+                            let immediate = src2.off_or_imm;
+                            push_asm(format!("  sub {dst_reg}, {immediate}").as_str());
+                        }
+                        (dst, src) => {
+                            todo!("sub {dst:?} {src:?}")
+                        }
+                    }
+                }
                 IR::Label { name } => push_asm(format!("{name}:").as_str()),
                 _ => push_asm("; Can't generate ASM for that yet")
             }

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -1,5 +1,27 @@
 
 use crate::new::instr;
+use crate::new::instr::OperandType;
+
+use super::instr::{Register, RegMode};
+
+const REG_64BIT: [&str; 16] = [
+    "rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
+];
+const REG_32BIT: [&str; 16] = [
+    "eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", "r8d", "r9d", "r10d", "r11d", "r12d", "r13d", "r14d", "r15d",
+];
+
+fn reg(r: Register, rm: RegMode) -> &'static str {
+    let index = r as usize;
+    debug_assert!(index < REG_32BIT.len());
+    if rm == RegMode::BIT32 {
+        REG_32BIT[index]
+    } else if rm == RegMode::BIT64 {
+        REG_64BIT[index]
+    } else {
+        unreachable!()
+    }
+}
 
 pub struct Assembler {
     print_debug: bool,

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -119,6 +119,12 @@ impl Assembler {
                             let val = value.off_or_imm;
                             push_asm(format!("  mov DWORD [rbp-{offset}-4], {val}").as_str());
                         }
+                        (OperandType::Offset, OperandType::ImmI64
+                                            | OperandType::ImmU64) => {
+                            let offset = addr.off_or_imm;
+                            let val = value.off_or_imm;
+                            push_asm(format!("  mov QWORD [rbp-{offset}-8], {val}").as_str());
+                        }
                         (OperandType::Reg, OperandType::Reg) => {
                             let dst = reg(addr.reg, addr.reg_mode);
                             let src = reg(value.reg, value.reg_mode);
@@ -176,6 +182,11 @@ impl Assembler {
                             let offset = src2.off_or_imm;
                             push_asm(format!("  add {dst_reg}, {offset}").as_str());
                         }
+                        (OperandType::Reg, OperandType::ImmI32
+                                            | OperandType::ImmU32) => {
+                            let immediate = src2.off_or_imm;
+                            push_asm(format!("  add {dst_reg}, {immediate}").as_str());
+                        }
                         (dst, src) => {
                             todo!("add {dst:?} {src:?}")
                         }
@@ -195,9 +206,7 @@ impl Assembler {
                             push_asm(format!("  sub {dst_reg}, {offset}").as_str());
                         }
                         (OperandType::Reg, OperandType::ImmI32
-                                            | OperandType::ImmI64
-                                            | OperandType::ImmU32
-                                            | OperandType::ImmU64) => {
+                                            | OperandType::ImmU32) => {
                             let immediate = src2.off_or_imm;
                             push_asm(format!("  sub {dst_reg}, {immediate}").as_str());
                         }

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -77,6 +77,21 @@ impl Assembler {
             match ir {
                 IR::Add { dst, src1, src2 } => {
                     debug_assert!(dst == src1);
+                    debug_assert!(dst.reg != instr::Register::None);
+                    let dst_reg = reg(dst.reg, dst.reg_mode);
+                    match (dst.typ, src2.typ) {
+                        (OperandType::Reg, OperandType::Reg) => {
+                            let src_reg = reg(src2.reg, src2.reg_mode);
+                            push_asm(format!("  add {dst_reg}, {src_reg}").as_str());
+                        }
+                        (OperandType::Reg, OperandType::Offset) => {
+                            let offset = src2.off_or_imm;
+                            push_asm(format!("  add {dst_reg}, {offset}").as_str());
+                        }
+                        (dst, src) => {
+                            todo!("add {dst:?} {src:?}")
+                        }
+                    }
                 }
                 IR::Label { name } => push_asm(format!("{name}:").as_str()),
                 _ => push_asm("; Can't generate ASM for that yet")

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -278,6 +278,33 @@ impl Assembler {
 
                 // Control Flow
                 IR::Label { name } => push_asm(format!("{name}:").as_str()),
+                IR::Cmp { dst, src } => {
+                    debug_assert!(dst.typ == OperandType::Reg);
+                    let dst_reg = reg(dst.reg, dst.reg_mode);
+                    match (dst.typ, src.typ) {
+                        (OperandType::Reg, OperandType::Reg) => {
+                            let src_reg = reg(src.reg, src.reg_mode);
+                            push_asm(format!("  cmp {dst_reg}, {src_reg}").as_str());
+                        }
+                        (OperandType::Reg, OperandType::ImmI32
+                            | OperandType::ImmI64
+                            | OperandType::ImmU32
+                            | OperandType::ImmU64) => {
+                            let immediate = src.off_or_imm;
+                            push_asm(format!("  cmp {dst_reg}, {immediate}").as_str());
+                        }
+                        (dst, src) => {
+                            todo!("cmp {dst:?} {src:?}")
+                        }
+                    }
+                }
+                IR::Jmp { name } => push_asm(format!("  jmp {name}").as_str()),
+                IR::JmpEq { name } => push_asm(format!("  je {name}").as_str()),
+                IR::JmpNeq { name } => push_asm(format!("  jne {name}").as_str()),
+                IR::JmpLt { name } => push_asm(format!("  jl {name}").as_str()),
+                IR::JmpLte { name } => push_asm(format!("  jle {name}").as_str()),
+                IR::JmpGt { name } => push_asm(format!("  jg {name}").as_str()),
+                IR::JmpGte { name } => push_asm(format!("  jge {name}").as_str()),
 
                 // Functions
                 IR::Call { name } => {

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -1,0 +1,68 @@
+
+use crate::new::instr;
+
+pub struct Assembler {
+    print_debug: bool,
+    path: String,
+}
+
+impl Assembler {
+    pub fn new() -> Self {
+        Self {
+            print_debug: false,
+            path: String::new()
+        }
+    }
+
+    pub fn filepath(self, path: &String) -> Self {
+        Self {
+            path: path.clone(),
+            ..self
+        }
+    }
+
+    pub fn debug(self, print_debug: bool) -> Self {
+        Self {
+            print_debug,
+            ..self
+        }
+    }
+
+    pub fn generate_x86_64(&self, ir: Vec<instr::IR>) -> Result<(), String> {
+        println!("{}", "-".repeat(50));
+        let mut output = String::new();
+        let mut push_asm = |s: &str| {
+            output.push_str(s.clone());
+            output.push('\n');
+        };
+
+        push_asm(format!("  ; Generated code for {}", self.path).as_str());
+        push_asm("default rel");
+        push_asm("");
+
+        push_asm("segment .text");
+        push_asm("  global main");
+        push_asm("  extern ExitProcess");
+        push_asm("  extern printf");
+        push_asm("  extern malloc");
+        push_asm("");
+
+        for ir in &ir {
+            if self.print_debug {
+                push_asm(format!("; -- {ir:?} --").as_str());
+            }
+            use instr::IR;
+            match ir {
+                IR::Add { dst, src1, src2 } => {
+                    debug_assert!(dst == src1);
+                }
+                IR::Label { name } => push_asm(format!("{name}:").as_str()),
+                _ => push_asm("; Can't generate ASM for that yet")
+            }
+        }
+
+        println!("{}", output);
+
+        Ok(())
+    }
+}

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -65,7 +65,6 @@ impl Assembler {
     }
 
     pub fn generate_x86_64(&self, ir: Vec<instr::IR>) -> Result<(), String> {
-        println!("{}", "-".repeat(50));
         let mut output = String::new();
         let mut push_asm = |s: &str| {
             output.push_str(s.clone());
@@ -430,5 +429,26 @@ impl Assembler {
         }
 
         Ok(())
+    }
+
+    pub fn run(&self) -> Result<(), String> {
+        let mut output_path = String::from(OUTPUT_FOLDER);
+        output_path.push_str(&self.path.replace(FILE_EXT, ".exe"));
+
+        if self.print_debug {
+            println!("Running `{output_path}`");
+        }
+
+        let output = Command::new(output_path)
+            .output()
+            .expect("failed to execute process");
+        let exit_code = output.status.code().unwrap();
+        if exit_code != 0 {
+            Err(format!(
+                "{}: Code execution failed with code 0x{:X}.", ERR_STR, exit_code
+            ))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -97,18 +97,14 @@ impl Assembler {
                         (OperandType::Offset, OperandType::Reg) => {
                             let offset = addr.off_or_imm;
                             let reg = reg(value.reg, value.reg_mode);
-                            // FIXME: I think this is incorrect and doesnt account for type size
-                            push_asm(format!("  mov [rbp-{offset}], {reg}").as_str());
+                            let size = if value.reg_mode == RegMode::BIT32 { 4 } else { 8 };
+                            push_asm(format!("  mov [rbp-{offset}-{size}], {reg}").as_str());
                         }
                         (OperandType::Offset, OperandType::ImmI32
-                                            | OperandType::ImmI64
-                                            | OperandType::ImmU32
-                                            | OperandType::ImmU64) => {
+                                            | OperandType::ImmU32) => {
                             let offset = addr.off_or_imm;
                             let val = value.off_or_imm;
-                            // FIXME: I think this is incorrect and doesnt account for type size
-                            // FIXME: Add WORD-size
-                            push_asm(format!("  mov [rbp-{offset}], {val}").as_str());
+                            push_asm(format!("  mov DWORD [rbp-{offset}-4], {val}").as_str());
                         }
                         (OperandType::Reg, OperandType::Reg) => {
                             let dst = reg(addr.reg, addr.reg_mode);
@@ -123,8 +119,8 @@ impl Assembler {
                         (OperandType::Reg, OperandType::Offset) => {
                             let reg = reg(dst.reg, dst.reg_mode);
                             let offset = addr.off_or_imm;
-                            // FIXME: I think this is incorrect and doesnt account for type size
-                            push_asm(format!("  mov {reg}, [rbp-{offset}]").as_str());
+                            let size = if dst.reg_mode == RegMode::BIT32 { 4 } else { 8 };
+                            push_asm(format!("  mov {reg}, [rbp-{offset}-{size}]").as_str());
                         }
                         (OperandType::Reg, OperandType::Reg) => {
                             let dst = reg(dst.reg, dst.reg_mode);

--- a/src/new/new_assembler.rs
+++ b/src/new/new_assembler.rs
@@ -340,6 +340,13 @@ impl Assembler {
                 }
             }
         }
+        push_asm("");
+        push_asm("segment .data");
+        push_asm("STACK_OVERFLOW_CODE dq 2");
+        push_asm("FUNCTION_COUNTER dq 0");
+        push_asm("FUNCTION_LIMIT dq 4096");
+        push_asm("");
+        push_asm("segment .bss");
 
         println!("{}", output);
         if invalid {

--- a/src/new/new_checker.rs
+++ b/src/new/new_checker.rs
@@ -1284,8 +1284,8 @@ impl Typecheckable for nodes::ExpressionFieldAccessNode {
                         self.name
                     ));
                 }
-                let typ = self.type_check_field(checker, var)?;
-                self.typ = typ.clone();
+                let typ = self.type_check_field(checker, var.clone())?;
+                self.typ = var.typ;
                 Ok(typ)
             }
             None => {

--- a/src/new/new_checker.rs
+++ b/src/new/new_checker.rs
@@ -350,16 +350,6 @@ impl TypeChecker {
         }
         None
     }
-
-    fn get_type_size(&self, typ: &Type) -> usize {
-        match typ {
-            Type::Arr(t, size) => self.get_type_size(t) * size.iter().product::<usize>(),
-            Type::I32 | Type::U32 => 4,
-            Type::I64 | Type::U64 | Type::Usize => 8,
-            Type::Class(..) => 8,
-            e => todo!("Figure out size of type {:?} in bytes", e),
-        }
-    }
 }
 
 trait Typecheckable {
@@ -585,7 +575,7 @@ impl Typecheckable for nodes::MethodNode {
 impl Typecheckable for nodes::ParameterNode {
     fn type_check(&mut self, checker: &mut TypeChecker) -> Result<Type, String> where Self: Sized {
         self.typ.type_check(checker);
-        let var_size = checker.get_type_size(&self.typ.typ);
+        let var_size = self.typ.typ.size();
         checker.current_stack_size += var_size;
         Ok(Type::None)
     }
@@ -642,7 +632,7 @@ impl Typecheckable for nodes::LetNode {
             None => {
                 self.typ.type_check(checker)?;
 
-                let var_size = checker.get_type_size(&self.typ.typ);
+                let var_size = self.typ.typ.size();
                 checker.current_stack_size += var_size;
 
                 let current_scope = checker.get_current_scope();

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -332,7 +332,7 @@ impl Codegenable for nodes::Statement {
 
 impl Codegenable for nodes::ExpressionNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        self.expression.codegen(codegen)
     }
 }impl Codegenable for nodes::LetNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
@@ -381,7 +381,19 @@ impl Codegenable for nodes::ArgumentNode {
 }
 impl Codegenable for nodes::Expression {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        match self {
+            Self::Name(expr) => expr.codegen(codegen),
+            Self::Identifier(expr) => expr.codegen(codegen),
+            Self::ArrayLiteral(expr) => expr.codegen(codegen),
+            Self::ArrayAccess(expr) => expr.codegen(codegen),
+            Self::Literal(expr) => expr.codegen(codegen),
+            Self::Binary(expr) => expr.codegen(codegen),
+            Self::Comparison(expr) => expr.codegen(codegen),
+            Self::FieldAccess(expr) => expr.codegen(codegen),
+            Self::FunctionCall(expr) => expr.codegen(codegen),
+            Self::ConstructorCall(expr) => expr.codegen(codegen),
+            Self::BuiltIn(expr) => expr.codegen(codegen),
+        }
     }
 }
 impl Codegenable for nodes::ExpressionArrayLiteralNode {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -180,6 +180,18 @@ impl Codegen {
         self.register_counter = 1;
     }
 
+    fn push_caller_saved_registers(&mut self) {
+        for reg in instr::Register::CALLER_SAVED {
+            self.add_ir(instr::IR::PushReg { reg });
+        }
+    }
+
+    fn pop_caller_saved_registers(&mut self) {
+        for reg in instr::Register::CALLER_SAVED.iter().rev() {
+            self.add_ir(instr::IR::PopReg { reg: *reg });
+        }
+    }
+
     fn add_ir(&mut self, ir: instr::IR) {
         println!("{:?}", ir);
         self.ir.push(ir)

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -42,7 +42,7 @@ impl SizeManager {
     }
 
     fn add_field(&mut self, class_name: &String, field_name: &String, typ: &Type) {
-        let size = self.get_type_size(typ);
+        let size = typ.size();
         let Some(class) = self.class_sizes.get_mut(class_name) else {
             // Two Options: Forgot to add class to Manager, or Type Checker f*ed up.
             unreachable!();
@@ -50,14 +50,8 @@ impl SizeManager {
         class.add_field(field_name, size);
     }
 
-    fn get_type_size(&self, typ: &Type) -> usize {
-        match typ {
-            Type::Arr(t, size) => self.get_type_size(t) * size.iter().product::<usize>(),
-            Type::I32 | Type::U32 => 4,
-            Type::I64 | Type::U64 | Type::Usize => 8,
-            Type::Class(..) => 8,
-            e => todo!("Figure out size of type {:?} in bytes", e),
-        }
+    fn get_class_info(&self, name: &String) -> &ClassInfo {
+        self.class_sizes.get(name).unwrap()
     }
 
     fn get_class_size(&self, class_name: &String) -> usize {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -705,7 +705,20 @@ impl Codegenable for nodes::ExpressionBinaryNode {
 }
 impl Codegenable for nodes::ExpressionComparisonNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        let lhs = self.lhs.codegen(codegen)?;
+        debug_assert!(lhs != instr::Operand::None);
+        if let instr::Operand::Reg(_, _) = lhs {} else {
+            // basically assert that LHS is a register for now
+            // we need to handle LHS=Imm later on
+            panic!()
+        }
+        let rhs = self.rhs.codegen(codegen)?;
+        debug_assert!(rhs != instr::Operand::None);
+        codegen.add_ir(instr::IR::Cmp {
+            dst: lhs,
+            src: rhs
+        });
+        Ok(instr::Operand::Cmp(self.operation))
     }
 }
 impl Codegenable for nodes::ExpressionCallNode {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -70,6 +70,8 @@ impl SizeManager {
 pub struct Codegen {
     sm: SizeManager,
     current_class: String,
+    ir: Vec<instr::IR>,
+    label_counter: usize,
     print_debug: bool
 }
 impl Codegen {
@@ -77,6 +79,8 @@ impl Codegen {
         Self {
             sm: SizeManager::new(),
             current_class: String::new(),
+            ir: Vec::new(),
+            label_counter: 0,
             print_debug: false
          }
     }
@@ -106,6 +110,10 @@ impl Codegen {
             println!("[DEBUG] Added new field `{}` to class `{}`", name, self.current_class);
             println!("[DEBUG] Class `{}` has a size of {} bytes now.", self.current_class, self.sm.get_class_size(&self.current_class));
         }
+    }
+
+    fn add_ir(&mut self, ir: instr::IR) {
+        self.ir.push(ir)
     }
 
     pub fn compile(&mut self) -> Result<(), String> {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -518,7 +518,7 @@ impl Codegenable for nodes::TypeNode {
 }
 impl Codegenable for nodes::ArgumentNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        self.expression.codegen(codegen)
     }
 }
 impl Codegenable for nodes::Expression {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -2,7 +2,7 @@
 use std::collections::{HashMap, VecDeque};
 
 use super::nodes;
-use crate::checker::Type;
+use crate::{checker::Type, new::new_parser::Operation};
 use super::instr;
 
 const LBL_STR: &str = "lbl_";
@@ -660,7 +660,47 @@ impl Codegenable for nodes::ExpressionLiteralNode {
 }
 impl Codegenable for nodes::ExpressionBinaryNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        let lhs = self.lhs.codegen(codegen)?;
+        debug_assert!(lhs != instr::Operand::None);
+        if let instr::Operand::Reg(_, _) = lhs {} else {
+            // basically assert that LHS is a register for now
+            // we need to handle LHS=Imm later on
+            panic!()
+        }
+        let rhs = self.rhs.codegen(codegen)?;
+        debug_assert!(rhs != instr::Operand::None);
+        match &self.operation {
+            Operation::PLUS => {
+                codegen.add_ir(instr::IR::Add {
+                    dst: lhs,
+                    src1: lhs,
+                    src2: rhs
+                });
+            },
+            Operation::MINUS => {
+                codegen.add_ir(instr::IR::Sub {
+                    dst: lhs,
+                    src1: lhs,
+                    src2: rhs
+                });
+            },
+            Operation::MULT => {
+                codegen.add_ir(instr::IR::Mul {
+                    dst: lhs,
+                    src1: lhs,
+                    src2: rhs
+                });
+            },
+            Operation::DIV => {
+                codegen.add_ir(instr::IR::Div {
+                    dst: lhs,
+                    src1: lhs,
+                    src2: rhs
+                });
+            },
+            _ => todo!()
+        }
+        Ok(lhs)
     }
 }
 impl Codegenable for nodes::ExpressionComparisonNode {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -91,7 +91,7 @@ impl Codegen {
             current_stack_offset: 0,
             stack_scopes: Vec::new(),
             field_stack: Vec::new(),
-            register_counter: 1,
+            register_counter: 0,
             print_debug: false
          }
     }
@@ -161,8 +161,8 @@ impl Codegen {
     }
 
     fn get_register(&mut self) -> Result<instr::Register, String> {
-        let v = self.register_counter;
         self.register_counter += 1;
+        let v = self.register_counter;
         if self.register_counter == instr::Register::__COUNT as usize {
             todo!()
         } else {
@@ -177,7 +177,8 @@ impl Codegen {
     }
 
     fn reset_registers(&mut self) {
-        self.register_counter = 1;
+        // even if register 0 (RAX) is reserved, get_register() increases this counter before returning it, so it's ok.
+        self.register_counter = 0;
     }
 
     fn push_preserved_registers(&mut self) {
@@ -636,8 +637,7 @@ impl Codegenable for nodes::ExpressionConstructorNode {
         let result_mode = instr::RegMode::from(&self.typ);
         let result = instr::Operand::Reg(result, result_mode);
 
-        // FIXME: Why -1?
-        let counter = codegen.register_counter - 1;
+        let counter = codegen.register_counter;
         codegen.push_registers(counter);
 
         // Codegen each argument and move it into the correct registers

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -210,7 +210,6 @@ impl Codegen {
     }
 
     fn add_ir(&mut self, ir: instr::IR) {
-        println!("{:?}", ir);
         self.ir.push(ir)
     }
 
@@ -241,7 +240,7 @@ impl Codegen {
             }
         }
         println!("Could not find {name} in {scopes:?}", scopes=self.stack_scopes);
-        unreachable!()
+        panic!()
     }
 
     fn store_variable_in_stack(&mut self, name: &String, typ: &Type) -> Result<(), String> {
@@ -276,7 +275,7 @@ impl Codegenable for nodes::FileNode {
         for function in &self.functions {
             function.codegen(codegen)?;
         }
-        todo!()
+        Ok(instr::Operand::None)
     }
 }
 

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -255,7 +255,36 @@ impl Codegen {
     }
 
     pub fn compile(&mut self) -> Result<(), String> {
-        todo!()
+        println!("{}", "-".repeat(50));
+        let mut output = String::new();
+        let mut push_asm = |s: &str| {
+            output.push_str(s.clone());
+            output.push('\n');
+        };
+
+        push_asm(format!("  ; Generated code for {}", "TODO: Figure out filename").as_str());
+        push_asm("default rel");
+        push_asm("");
+
+        push_asm("segment .text");
+        push_asm("  global main");
+        push_asm("  extern ExitProcess");
+        push_asm("  extern printf");
+        push_asm("  extern malloc");
+        push_asm("");
+
+        for ir in &self.ir {
+            if self.print_debug {
+                push_asm(format!("; -- {ir:?} --").as_str());
+            }
+            match ir {
+                _ => push_asm("; Can't generate ASM for that yet")
+            }
+        }
+
+        println!("{}", output);
+
+        Ok(())
     }
 
     pub fn run(&mut self) -> Result<(), String> {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -318,7 +318,13 @@ impl Codegenable for nodes::BlockNode {
 
 impl Codegenable for nodes::Statement {
     fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
-        todo!()
+        match self {
+            Self::Assign(assign_node) => assign_node.codegen(codegen),
+            Self::Expression(expr_node) => expr_node.codegen(codegen),
+            Self::If(if_node) => if_node.codegen(codegen),
+            Self::Let(let_node) => let_node.codegen(codegen),
+            Self::Return(ret_node) => ret_node.codegen(codegen)
+        }
     }
 }
 

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -737,18 +737,14 @@ impl nodes::ExpressionFieldAccessNode {
                 let Type::Class(class_name) = class_type else { panic!() };
 
                 let offset = codegen.get_field_offset(&class_name, &name_node.name);
-                let reg = codegen.get_register()?;
-                let reg = instr::Operand::Reg(reg, instr::RegMode::from(&name_node.typ));
-                codegen.add_ir(instr::IR::LoadImm {
-                    dst: reg,
-                    // FIXME: Improve this
-                    imm: if name_node.typ.size() == 4 {
-                        instr::Operand::ImmU32(offset as u32)
-                    } else {
-                        instr::Operand::ImmU64(offset as u64)
-                    }
-                });
-                Ok(reg)
+                // let reg = codegen.get_register()?;
+                // let reg = instr::Operand::Reg(reg, instr::RegMode::from(&name_node.typ));
+                let imm = if name_node.typ.size() == 4 {
+                    instr::Operand::ImmU32(offset as u32)
+                } else {
+                    instr::Operand::ImmU64(offset as u64)
+                };
+                Ok(imm)
             }
             nodes::Expression::FunctionCall(fn_call) => {
                 todo!()

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -309,14 +309,16 @@ impl Codegenable for nodes::FeatureNode {
         // Function body
         self.block.codegen(codegen)?;
 
+        // Return procedure
+        let label = codegen.generate_label(Some(name + "_return"));
+        codegen.add_ir(label);
+
         // Clean up stack offset
         codegen.add_ir(instr::IR::DeallocStack { bytes });
 
-        // Return
-        let label = codegen.generate_label(Some(name + "_return"));
-        codegen.add_ir(label);
         codegen.add_ir(instr::IR::Return);
 
+        codegen.current_stack_offset = 0;
         codegen.leave_scope();
         Ok(instr::Operand::None)
     }

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -298,6 +298,7 @@ impl Codegenable for nodes::FeatureNode {
         for param in &self.parameters {
             param.codegen(codegen)?;
         }
+        codegen.reset_registers();
 
         if self.is_constructor {
             // let this: Class = alloc(sizeof(Class));
@@ -382,6 +383,7 @@ impl Codegenable for nodes::MethodNode {
         for param in &self.parameters {
             param.codegen(codegen)?;
         }
+        codegen.reset_registers();
 
         // Function body
         self.block.codegen(codegen)?;

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -715,14 +715,16 @@ impl Codegenable for nodes::ExpressionBinaryNode {
                 codegen.add_ir(instr::IR::Mul {
                     dst: lhs,
                     src1: lhs,
-                    src2: rhs
+                    src2: rhs,
+                    signed: self.typ == Type::I32 || self.typ == Type::I64
                 });
             },
             Operation::DIV => {
                 codegen.add_ir(instr::IR::Div {
                     dst: lhs,
                     src1: lhs,
-                    src2: rhs
+                    src2: rhs,
+                    signed: self.typ == Type::I32 || self.typ == Type::I64
                 });
             },
             _ => todo!()

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -175,8 +175,8 @@ impl Codegen {
         let offset = self.update_stack_offset(typ.size());
         let reg = self.get_register()?;
         self.add_variable_offset(name, offset);
-        self.add_ir(instr::IR::StoreStack {
-            offset: instr::Operand::MemOffset(offset),
+        self.add_ir(instr::IR::Store {
+            addr: instr::Operand::StackOffset(offset),
             value: instr::Operand::Reg(reg, instr::RegMode::from(typ))
         });
         Ok(())
@@ -341,7 +341,17 @@ impl Codegenable for nodes::ExpressionNode {
 }
 impl Codegenable for nodes::AssignNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        let rhs = self.expression.codegen(codegen)?;
+        debug_assert!(rhs != instr::Operand::None);
+        
+        let lhs = self.name.codegen(codegen)?;
+        debug_assert!(lhs != instr::Operand::None);
+
+        codegen.add_ir(instr::IR::Store {
+            addr: lhs,
+            value: rhs
+        });
+        Ok(instr::Operand::None)
     }
 }
 impl Codegenable for nodes::ExpressionIdentifierNode {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -562,7 +562,36 @@ impl Codegenable for nodes::ExpressionIdentifierNode {
 }
 impl Codegenable for nodes::IfNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        let cond = self.condition.codegen(codegen)?;
+        let instr::Operand::Cmp(cmp_mode) = cond else { unreachable!() };
+
+        let cond_false = codegen.generate_label(None);
+        let lbl_name = cond_false.get_lbl();
+        match cmp_mode {
+            Operation::EQ => codegen.add_ir(instr::IR::JmpNeq { name: lbl_name }),
+            Operation::NEQ => codegen.add_ir(instr::IR::JmpEq { name: lbl_name }),
+            Operation::GT => todo!(),
+            Operation::GTE => todo!(),
+            Operation::LT => todo!(),
+            Operation::LTE => todo!(),
+            _ => todo!()
+        }
+        self.if_branch.codegen(codegen)?;
+
+        if let Some(else_branch) = &self.else_branch {
+            let fin = codegen.generate_label(None);
+            let lbl_name = fin.get_lbl();
+            codegen.add_ir(instr::IR::Jmp { name: lbl_name });
+
+            codegen.add_ir(cond_false);
+
+            else_branch.codegen(codegen)?;
+
+            codegen.add_ir(fin);
+        } else {
+            codegen.add_ir(cond_false);
+        }
+        Ok(instr::Operand::None)
     }
 }
 impl Codegenable for nodes::ReturnNode {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -100,7 +100,8 @@ impl Codegen {
     }
 
     pub fn generate_code(&mut self, ast: &nodes::FileNode) -> Result<(), String> {
-        ast.codegen(self)
+        ast.codegen(self)?;
+        Ok(())
     }
 
     fn generate_label(&mut self, name: Option<String>) -> instr::IR {
@@ -191,11 +192,11 @@ impl Codegen {
 }
 
 trait Codegenable {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String>;
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String>;
 }
 
 impl Codegenable for nodes::FileNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         for class in &self.classes {
             class.codegen(codegen)?;
         }
@@ -207,7 +208,7 @@ impl Codegenable for nodes::FileNode {
 }
 
 impl Codegenable for nodes::ClassNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         debug_assert!(codegen.current_class.is_empty());
         codegen.add_class(&self.name);
         codegen.current_class = self.name.clone();
@@ -229,20 +230,20 @@ impl Codegenable for nodes::ClassNode {
     }
 }
 impl Codegenable for nodes::FieldNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         let typ = &self.type_def.typ;
         debug_assert!(*typ != Type::None);
         codegen.add_field(&self.name, typ);
-        Ok(())
+        Ok(instr::Operand::None)
     }
 }
 impl Codegenable for nodes::FieldAccess {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::FeatureNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         // TODO: Make this a macro, it's the same thing for Functions and Methods
         debug_assert!(!codegen.current_class.is_empty());
         debug_assert!(codegen.current_stack_offset == 0);
@@ -282,31 +283,32 @@ impl Codegenable for nodes::FeatureNode {
         codegen.add_ir(instr::IR::Return);
 
         codegen.leave_scope();
-        Ok(())
+        Ok(instr::Operand::None)
     }
 }
 impl Codegenable for nodes::FunctionNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::MethodNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ReturnTypeNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ParameterNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
-        codegen.store_variable_in_stack(&self.name, &self.typ.typ)
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
+        codegen.store_variable_in_stack(&self.name, &self.typ.typ)?;
+        Ok(instr::Operand::None)
     }
 }
 impl Codegenable for nodes::BlockNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         codegen.enter_scope();
         for stmt in &self.statements {
             stmt.codegen(codegen)?;
@@ -317,7 +319,7 @@ impl Codegenable for nodes::BlockNode {
 }
 
 impl Codegenable for nodes::Statement {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         match self {
             Self::Assign(assign_node) => assign_node.codegen(codegen),
             Self::Expression(expr_node) => expr_node.codegen(codegen),
@@ -329,96 +331,96 @@ impl Codegenable for nodes::Statement {
 }
 
 impl Codegenable for nodes::ExpressionNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }impl Codegenable for nodes::LetNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::AssignNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionIdentifierNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::IfNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ReturnNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::TypeNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ArgumentNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::Expression {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionArrayLiteralNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionArrayAccessNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionLiteralNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionBinaryNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionComparisonNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionCallNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionConstructorNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionFieldAccessNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::NameNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }
 impl Codegenable for nodes::ExpressionBuiltInNode {
-    fn codegen(&self, codegen: &mut Codegen) -> Result<(), String> {
+    fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         todo!()
     }
 }

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -684,11 +684,9 @@ impl Codegenable for nodes::ExpressionBinaryNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         let lhs = self.lhs.codegen(codegen)?;
         debug_assert!(lhs != instr::Operand::none());
-        if let instr::OperandType::Reg(_) = lhs.typ {} else {
-            // basically assert that LHS is a register for now
-            // we need to handle LHS=Imm later on
-            panic!()
-        }
+        // we need to handle LHS=Imm later on
+        debug_assert!(lhs.typ == instr::OperandType::Reg);
+
         let rhs = self.rhs.codegen(codegen)?;
         debug_assert!(rhs != instr::Operand::none());
         match &self.operation {
@@ -731,11 +729,9 @@ impl Codegenable for nodes::ExpressionComparisonNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
         let lhs = self.lhs.codegen(codegen)?;
         debug_assert!(lhs != instr::Operand::none());
-        if let instr::OperandType::Reg(_) = lhs.typ {} else {
-            // basically assert that LHS is a register for now
-            // we need to handle LHS=Imm later on
-            panic!()
-        }
+        // we need to handle LHS=Imm later on
+        debug_assert!(lhs.typ == instr::OperandType::Reg);
+
         let rhs = self.rhs.codegen(codegen)?;
         debug_assert!(rhs != instr::Operand::none());
         codegen.add_ir(instr::IR::Cmp {
@@ -766,10 +762,10 @@ impl Codegenable for nodes::ExpressionCallNode {
             debug_assert!(op != instr::Operand::none());
             let target_reg = instr::Register::arg(index);
             match op.typ {
-                instr::OperandType::Reg(mode) => {
+                instr::OperandType::Reg => {
                     if op.reg != target_reg {
                         // Move to correct register if necessary
-                        let target_reg = instr::Operand::reg(target_reg, mode);
+                        let target_reg = instr::Operand::reg(target_reg, op.reg_mode);
                         codegen.add_ir(instr::IR::Move {
                             dst: target_reg,
                             src: op,
@@ -827,10 +823,10 @@ impl Codegenable for nodes::ExpressionConstructorNode {
             debug_assert!(op != instr::Operand::none());
             let target_reg = instr::Register::arg(index);
             match op.typ {
-                instr::OperandType::Reg(mode) => {
+                instr::OperandType::Reg => {
                     if op.reg != target_reg {
                         // Move to correct register if necessary
-                        let target_reg = instr::Operand::reg(target_reg, mode);
+                        let target_reg = instr::Operand::reg(target_reg, op.reg_mode);
                         codegen.add_ir(instr::IR::Move {
                             dst: target_reg,
                             src: op,

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -313,6 +313,14 @@ impl Codegenable for nodes::FeatureNode {
         let label = codegen.generate_label(Some(name + "_return"));
         codegen.add_ir(label);
 
+        if self.is_constructor {
+            let offset = codegen.get_stack_offset(&String::from("this"));
+            codegen.add_ir(instr::IR::Load {
+                dst: instr::Operand::Reg(instr::Operand::RET, instr::RegMode::BIT64),
+                addr: instr::Operand::StackOffset(offset)
+            });
+        }
+
         // Clean up stack offset
         codegen.add_ir(instr::IR::DeallocStack { bytes });
 

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -157,6 +157,10 @@ impl Codegen {
         }
     }
 
+    fn reset_registers(&mut self) {
+        self.register_counter = 1;
+    }
+
     fn add_ir(&mut self, ir: instr::IR) {
         println!("{:?}", ir);
         self.ir.push(ir)
@@ -365,13 +369,15 @@ impl Codegenable for nodes::BlockNode {
 
 impl Codegenable for nodes::Statement {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        match self {
+        let reg = match self {
             Self::Assign(assign_node) => assign_node.codegen(codegen),
             Self::Expression(expr_node) => expr_node.codegen(codegen),
             Self::If(if_node) => if_node.codegen(codegen),
             Self::Let(let_node) => let_node.codegen(codegen),
             Self::Return(ret_node) => ret_node.codegen(codegen)
-        }
+        };
+        codegen.reset_registers();
+        reg
     }
 }
 

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -245,8 +245,8 @@ impl Codegen {
 
     fn store_variable_in_stack(&mut self, name: &String, typ: &Type) -> Result<(), String> {
         let offset = self.update_stack_offset(typ.size());
-        let reg = self.get_register()?;
         self.add_variable_offset(name, offset);
+        let reg = self.get_register()?;
         self.add_ir(instr::IR::Store {
             addr: instr::Operand::StackOffset(offset),
             value: instr::Operand::Reg(reg, instr::RegMode::from(typ))
@@ -480,7 +480,18 @@ impl Codegenable for nodes::ExpressionNode {
     }
 }impl Codegenable for nodes::LetNode {
     fn codegen(&self, codegen: &mut Codegen) -> Result<instr::Operand, String> {
-        todo!()
+        let rhs = self.expression.codegen(codegen)?;
+        debug_assert!(rhs != instr::Operand::None);
+
+        let offset = codegen.update_stack_offset(self.typ.typ.size());
+        codegen.add_variable_offset(&self.name, offset);
+
+        codegen.add_ir(instr::IR::Store {
+            addr: instr::Operand::StackOffset(offset),
+            value: rhs
+        });
+
+        Ok(instr::Operand::None)
     }
 }
 impl Codegenable for nodes::AssignNode {

--- a/src/new/new_codegen.rs
+++ b/src/new/new_codegen.rs
@@ -114,10 +114,10 @@ impl Codegen {
         self.current_class.clear();
     }
 
-    pub fn generate_code(&mut self, ast: &nodes::FileNode) -> Result<(), String> {
+    pub fn generate_code(&mut self, ast: &nodes::FileNode) -> Result<Vec<instr::IR>, String> {
         self.fill_lookup(ast);
         ast.codegen(self)?;
-        Ok(())
+        Ok(self.ir.clone())
     }
 
     fn generate_label(&mut self, name: Option<String>) -> instr::IR {
@@ -251,39 +251,6 @@ impl Codegen {
             addr: instr::Operand::offset(offset),
             value: instr::Operand::reg(reg, instr::RegMode::from(typ))
         });
-        Ok(())
-    }
-
-    pub fn compile(&mut self) -> Result<(), String> {
-        println!("{}", "-".repeat(50));
-        let mut output = String::new();
-        let mut push_asm = |s: &str| {
-            output.push_str(s.clone());
-            output.push('\n');
-        };
-
-        push_asm(format!("  ; Generated code for {}", "TODO: Figure out filename").as_str());
-        push_asm("default rel");
-        push_asm("");
-
-        push_asm("segment .text");
-        push_asm("  global main");
-        push_asm("  extern ExitProcess");
-        push_asm("  extern printf");
-        push_asm("  extern malloc");
-        push_asm("");
-
-        for ir in &self.ir {
-            if self.print_debug {
-                push_asm(format!("; -- {ir:?} --").as_str());
-            }
-            match ir {
-                _ => push_asm("; Can't generate ASM for that yet")
-            }
-        }
-
-        println!("{}", output);
-
         Ok(())
     }
 

--- a/src/new/new_parser.rs
+++ b/src/new/new_parser.rs
@@ -59,7 +59,7 @@ impl Token {
 }
 
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum Operation {
     PLUS,
     MINUS,

--- a/src/new/new_parser.rs
+++ b/src/new/new_parser.rs
@@ -651,6 +651,7 @@ impl Parsable for nodes::FeatureNode {
             return_type,
             parameters,
             block,
+            stack_size: 0,
         })
     }
 }
@@ -690,6 +691,7 @@ impl Parsable for nodes::FunctionNode {
             return_type,
             parameters,
             block,
+            stack_size: 0,
         })
     }
 }
@@ -731,6 +733,7 @@ impl Parsable for nodes::MethodNode {
             return_type,
             parameters,
             block,
+            stack_size: 0,
         })
     }
 }

--- a/src/new/new_parser.rs
+++ b/src/new/new_parser.rs
@@ -931,7 +931,8 @@ impl Parsable for nodes::ReturnNode {
         parser.expect(TokenType::Semi)?;
         Ok(nodes::ReturnNode {
             location,
-            return_value
+            return_value,
+            typ: Type::Unknown
         })
     }
 }

--- a/src/new/nodes.rs
+++ b/src/new/nodes.rs
@@ -43,6 +43,7 @@ pub struct FeatureNode {
     pub return_type: ReturnTypeNode,
     pub parameters: Vec<ParameterNode>,
     pub block: BlockNode,
+    pub stack_size: usize,
     pub is_constructor: bool
 }
 
@@ -52,7 +53,8 @@ pub struct FunctionNode {
     pub name: String,
     pub return_type: ReturnTypeNode,
     pub parameters: Vec<ParameterNode>,
-    pub block: BlockNode
+    pub block: BlockNode,
+    pub stack_size: usize
 }
 
 #[derive(Debug, Clone)]
@@ -62,7 +64,8 @@ pub struct MethodNode {
     pub name: String,
     pub return_type: ReturnTypeNode,
     pub parameters: Vec<ParameterNode>,
-    pub block: BlockNode
+    pub block: BlockNode,
+    pub stack_size: usize
 }
 
 #[derive(Debug, Clone)]

--- a/src/new/nodes.rs
+++ b/src/new/nodes.rs
@@ -136,6 +136,7 @@ pub struct IfNode {
 pub struct ReturnNode {
     pub location: Location,
     pub return_value: Option<ExpressionNode>,
+    pub typ: Type,
 }
 
 #[derive(Debug, Clone)]

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,22 +1,9 @@
-func foo(a: i32, b1: i32) -> i32 {
-    let b: i32 = 5;
-    let c: i32 = a * a;
-    if (c == 25) {
-        return b / b;
-    } else {
-        return 420;
-    }
-}
-
-func ack(m: u64, n: u64) -> u64 {
-    if (m == 0) { return n; }
+func ack(m: u32, n: u32) -> u32 {
+    if (m == 0) { return n + 1; }
     if (n == 0) { return ack(m - 1, 1); }
     return ack(m - 1, ack(m, n - 1));
 }
 
 func main() {
-    let a: i32 = 5;
-    let b: i32 = foo(a, a);
-    let c: u64 = ack(3, 3);
-    let d: i32 = a + b;
+    let a: u32 = ack(3, 5);
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -17,4 +17,5 @@ func ack(m: u64, n: u64) -> u64 {
 func main() {
     let a: i32 = 5;
     let b: i32 = foo(a, a);
+    let c: u64 = ack(3, 3);
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -1,62 +1,20 @@
-class Test {
-    a: i64;
-    b: Test;
-    c: i64;
-    d: i64;
-    feat new(na: i64, nb: i64, nc: i64) -> Test {
-        this.a = na;
-        // this.b = Test(0, 0, 0);
-        this.c = nc;
-        // this.d gets 0 initialized
-    }
-    func foo(b: i32) -> i64 {
-        return this.d;
-    }
-
-    func fee(b: i32) -> i32 {
-        return b;
-    }
-
-    func faa() {}
-}
-
-class Idee {
-    a: i64;
-    t: Test;
-
-    feat new(na: i64) {
-        this.a = na;
-        this.t = Test(this.a, 5, 10);
-        let a: i64 = this.a;
-        this.t.b.b.b.b.b.b.a = 10;
+func foo(a: i32, b1: i32) -> i32 {
+    let b: i32 = 5;
+    let c: i32 = a * a;
+    if (c == 25) {
+        return b / b;
+    } else {
+        return 420;
     }
 }
 
-func bla(t: Test, t1: Test) -> i64 {
-    return t.d + t1.d;
-}
-
-func retInstance(t: Test) -> Idee {
-    return Idee(t.d);
+func ack(m: u64, n: u64) -> u64 {
+    if (m == 0) { return n; }
+    if (n == 0) { return ack(m - 1, 1); }
+    return ack(m - 1, ack(m, n - 1));
 }
 
 func main() {
-    let test: Test = Test(2, 3, 4);
-    let idee: Idee = retInstance(test);
-    let e: i32 = 0;
-    let a: u64[3, 3] = [
-         [1 - 3, 2 * 4, 3 / 5],
-         [1 - 3, 2 * 4, 3 / 5],
-         [1 - 3, 2 * 4, 3 / 5],
-    ];
-    let d: i32 = 9;
-    d = 0;
-    test.d = 10;
-    idee.a = 12;
-    let f: i64 = test.foo(5);
-    if (d == 1) {
-
-    } else {
-
-    }
+    let a: i32 = 5;
+    let b: i32 = foo(a, a);
 }

--- a/src/test.bu
+++ b/src/test.bu
@@ -18,4 +18,5 @@ func main() {
     let a: i32 = 5;
     let b: i32 = foo(a, a);
     let c: u64 = ack(3, 3);
+    let d: i32 = a + b;
 }


### PR DESCRIPTION
Has been a long journey, but the compiler is back to a very early-access semi-stable state. It can successfully compile and run some programs again.

Next step is clean up, so:
- Remove old compiler architecture
- todo-cleanup
- FIXME-cleanup
- `cargo clippy` and `cargo fmt`