### PR TITLE
Function pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,24 @@
 
-all:
+all: bufo.exe hello.exe small.exe machine.exe
 	bufo.exe src/bufo.bufo -o bufo1.exe
 	mv bufo1.exe bufo.exe
+
+bufo.exe: src/bufo.bufo
 	bufo.exe src/bufo.bufo -o bufo1.exe
 	mv bufo1.exe bufo.exe
+
+hello.exe: hello.bufo
 	bufo.exe hello.bufo -o hello.exe
+
+small.exe: small.bufo
 	bufo.exe small.bufo -o small.exe
-#	 hello.exe
-	rm *.obj
+
+machine.exe: machine.bufo
+	bufo.exe machine.bufo -o machine.exe
 
 brick:
 	working.exe src/bufo.bufo -o bufo.exe
 
+clean:
+	rm -f *.s
+	rm -f *.obj

--- a/helper.py
+++ b/helper.py
@@ -322,7 +322,8 @@ def get_current_test_number() -> int:
             full = full.split("-")[0]
             full = full.replace("/", "")
             index = int(full)
-            assert index == current + 1, f"Missing index {index} in tests"
+            if index != current + 1:
+                return current + 1
             current = index
     return current + 1
 

--- a/machine.bufo
+++ b/machine.bufo
@@ -1,0 +1,561 @@
+import "prelude.bufo";
+import "libc.bufo";
+
+// Experiments to explore JIT compilation of function calls
+// Will be integrated into the compiler at some point
+
+// TODO: Struct values
+// TODO: Maybe stuff that's not 8 bytes long, like u8, f32, etc.
+// TODO: Struct values that are returned from the function -> Implicit first argument
+// TODO: Instead of recompiling the functions, we can just store pointers to the arguments
+//       and only overwrite those bytes
+// TODO: Calling convention for the OS for nerds :Kappa:
+// TODO: Passing arguments on the stack should consider the argument size
+
+// FIXME: Something causes a heap corruption for `betterRaylib` when I close the window
+//        Debugging indicates that it seems like _dlclose() is at fault
+
+// Some notes:
+// https://www.felixcloutier.com/x86/mov
+// https://blog.kenanb.com/code/low-level/2024/01/05/x86-64-insn-encoding.html
+// http://ref.x86asm.net/coder64.html#xC7
+// Intel Manual:
+// - page 526 Mod R/M
+// - page 593 meaning io rd /r
+// mov rax, 32bit immediate
+// push(&buf, '\x48', '\xc7', '\xc0', '\x45', '\x00', '\x00', '\x00', '\xC3');
+// mov rax, 64bit immediate
+// push(&buf, '\x48', '\xb8', '\x45', '\x00', '\x00', '\x00', '\x00', '\x00');
+// push(&buf, '\x00', '\x00', '\xC3');
+// movss xmm0, [rax + 32bit immediate] (f32)
+// push(&buf, '\xF3', '\x0F', '\x10', '\x80', '\x00', '\x00', '\x00', '\x00');
+// movss xmm0, [rcx] 32bit memory (f32)
+// push(&buf, '\xF3', '\x0F', '\x10', '\x81', '\x00', '\x00', '\x00', '\x00');
+// movsd xmm0, [rax] 64bit memory (f64)
+// push(&buf, '\xF2', '\x0F', '\x10', '\x80', '\x00', '\x00', '\x00', '\x00');
+// ret
+// push(&buf, '\xC3');
+// int3
+// push(&buf, '\xF1');
+// - mov = REX.W 0xB8 rd io
+// - movss = 0xF3 0x0F 0x10 /r
+// - movsd = 0xF2 0x0F 0x10 /r
+// - /r = Mod R/M -> 0x80 = RAX/XMM0 -> [RAX + offset]
+// - REX = -> 0x0100WRXB
+// - REX.W = W bit is 1 if 64bit operand -> 0x01001000 = 0x48
+// - REX.R = ???
+// - REX.X = ???
+// - REX.B = ???
+// - ib = 1-byte immediate, iw = 2-byte immediate, id = 4-byte immediate, io = 8-byte immediate
+// - rd = /r is encoded in the 3 bits of operand byte -> 0xb8 = mov rax, 0xb9 = mov rcx, 0xba = mov rdx etc.
+// - ModRM -> 2bits addressing mode, 3bits opcode extension, 3bits register
+// - /digit => opcode extension for ModRM
+
+@os(LINUX) @extern("dlopen") func dlopen(filename: &char, flags: i32) -> Any;
+@os(LINUX) @extern("dlclose") func dlclose(handle: Any) -> i32;
+
+@os(WINDOWS) @extern("LoadLibraryA") func _dlopen(filename: &char) -> Any;
+@os(WINDOWS) func dlopen(filename: &char, flags: i32) -> Any {
+    return _dlopen(filename);
+}
+@os(WINDOWS) @extern("FreeLibrary") func _dlclose(handle: Any) -> bool;
+@os(WINDOWS) func dlclose(handle: Any) -> i32 {
+    let b = _dlclose(handle);
+    if (!b) return 1;
+    return 0;
+}
+
+@os(WINDOWS) @extern("GetProcAddress") func GetProcAddress(handle: Any, name: &char) -> Any;
+@os(WINDOWS) @extern("VirtualAlloc") func VirtualAlloc(idk: Any, bytes: usize, flags: u32, pFlags: u32) -> Any;
+@os(WINDOWS) @extern("VirtualFree") func VirtualFree(address: Any, bytes: usize, flags: u32) -> bool;
+@os(WINDOWS) @extern("GetLastError") func GetLastError() -> u32;
+
+@os(WINDOWS) func getFunction(handle: Any, name: &char) -> Any {
+    let fn = GetProcAddress(handle, name);
+    assert(fn != null, "Could not find function");
+    return fn;
+}
+
+func raylib() {
+    let handle = dlopen("./raylib/lib/raylib.dll", 0);
+    assert(handle != null, "Could not load raylib.dll");
+    let InitWindow = getFunction(handle, "InitWindow") as func (usize, usize, &char);
+    let WindowShouldClose = getFunction(handle, "WindowShouldClose") as func () -> bool;
+    let BeginDrawing = getFunction(handle, "BeginDrawing") as func ();
+    let EndDrawing = getFunction(handle, "EndDrawing") as func ();
+    InitWindow(800, 600, "Ayo from Bufo!");
+    while (!WindowShouldClose()) {
+        BeginDrawing();
+        EndDrawing();
+    }
+    assert(dlclose(handle) == 0, "Could not close raylib.dll");
+}
+
+struct ByteBuffer {
+    elements: &u8;
+    length: usize;
+    capacity: usize;
+}
+
+func push(buf: &ByteBuffer, b1: char, b2: char, b3: char, b4: char, b5: char, b6: char, b7: char, b8: char) {
+    push(buf, b1 as u8, b2 as u8, b3 as u8, b4 as u8, b5 as u8, b6 as u8, b7 as u8, b8 as u8);
+}
+
+func push(buf: &ByteBuffer, b1: char, b2: char, b3: char, b4: char) {
+    push(buf, b1 as u8, b2 as u8);
+    push(buf, b3 as u8, b4 as u8);
+}
+func push(buf: &ByteBuffer, b1: char, b2: char, b3: char) {
+    push(buf, b1 as u8, b2 as u8);
+    push(buf, b3 as u8);
+}
+func push(buf: &ByteBuffer, b1: char, b2: char) {
+    push(buf, b1 as u8, b2 as u8);
+}
+func push(buf: &ByteBuffer, b1: char) {
+    push(buf, b1 as u8);
+}
+func push(buf: &ByteBuffer, b1: u8, b2: u8) {
+    push(buf, b1);
+    push(buf, b2);
+}
+func push(buf: &ByteBuffer, b1: u8, b2: u8, b3: u8, b4: u8, b5: u8, b6: u8, b7: u8, b8: u8) {
+    push(buf, b1);
+    push(buf, b2);
+    push(buf, b3);
+    push(buf, b4);
+    push(buf, b5);
+    push(buf, b6);
+    push(buf, b7);
+    push(buf, b8);
+}
+func push(buf: &ByteBuffer, element: u8) {
+    if (buf.length >= buf.capacity) {
+        let newCap: usize = buf.capacity * 2;
+        if (newCap == 0) newCap = 32;
+        buf.elements = realloc(buf.elements, newCap * sizeof u8);
+        assert(buf.elements != null, "Could not allocate memory in ByteBuffer.push");
+        buf.capacity = newCap;
+    }
+    buf.elements[buf.length] = element;
+    buf.length = buf.length + 1;
+}
+
+func extend(buf: &ByteBuffer, other: &ByteBuffer) {
+    for (let i: usize = 0; i < other.length; i = i + 1) {
+        push(buf, other.elements[i]);
+    }
+    free(other.elements);
+    *other = blank;
+}
+
+comptime U64: u8 = 0;
+comptime F64: u8 = 1;
+comptime F32: u8 = 2;
+comptime VOID: u8 = 3;
+
+comptime RAX: u8 = 0;
+comptime RCX: u8 = 1;
+comptime RDX: u8 = 2;
+comptime RBX: u8 = 3;
+comptime RSP: u8 = 4;
+comptime RBP: u8 = 5;
+comptime RSI: u8 = 6;
+comptime RDI: u8 = 7;
+comptime R8: u8 = 8;
+comptime R9: u8 = 9;
+comptime R10: u8 = 10;
+comptime R11: u8 = 11;
+comptime R12: u8 = 12;
+comptime R13: u8 = 13;
+comptime R14: u8 = 14;
+comptime R15: u8 = 15;
+
+comptime XMM0: u8 = 0;
+comptime XMM1: u8 = 1;
+comptime XMM2: u8 = 2;
+comptime XMM3: u8 = 3;
+
+comptime ADDR_INDIRECT: u8 = 0;
+comptime ADDR_DISP8: u8 = 1;
+comptime ADDR_DISP32: u8 = 2;
+comptime ADDR_REG: u8 = 3;
+
+@os(WINDOWS) comptime ARGS = [[RCX, XMM0], [RDX, XMM1], [R8, XMM2], [R9, XMM3]];
+
+struct Value {
+    kind: u8;
+    u64: u64;
+    f64: f64;
+    f32: f32;
+}
+
+struct ValueList {
+    elements: &Value;
+    length: usize;
+    capacity: usize;
+}
+func push(buf: &ValueList, element: Value) {
+    if (buf.length >= buf.capacity) {
+        let newCap: usize = buf.capacity * 2;
+        if (newCap == 0) newCap = 32;
+        buf.elements = realloc(buf.elements, newCap * sizeof Value);
+        assert(buf.elements != null, "Could not allocate memory in ValueList.push");
+        buf.capacity = newCap;
+    }
+    buf.elements[buf.length] = element;
+    buf.length = buf.length + 1;
+}
+
+func pushImm(bytes: &ByteBuffer, imm: u32) {
+    let _bytes = &imm as &u8;
+    for (let i: usize = 0; i < 4; i = i + 1) {
+        push(bytes, _bytes[i]);
+    }
+}
+
+func pushImm(bytes: &ByteBuffer, imm: u64) {
+    let _bytes = &imm as &u8;
+    for (let i: usize = 0; i < 8; i = i + 1) {
+        push(bytes, _bytes[i]);
+    }
+}
+
+func modRM(bytes: &ByteBuffer, addr: u8, opext: u8, reg: u8) {
+    let byte = shiftLeft(addr as usize, 6) as u8;
+    byte = byte | shiftLeft(opext as usize, 3) as u8;
+    byte = byte | (reg % 8);
+    push(bytes, byte);
+}
+
+func modPrefix(bytes: &ByteBuffer, r: u8) {
+    let rex: u8 = '\x48' as u8;
+    if (r >= 8) rex = rex | 1;
+    push(bytes, rex);
+}
+
+func mov(to: u8, from: u8) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    modPrefix(&bytes, from);
+    push(&bytes, '\x89');
+    modRM(&bytes, ADDR_REG, from, to);
+    return bytes;
+}
+
+func mov(r: u8, imm: u32) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    let opcode = (('\xb8' as u8) + (r % 8)) as char;
+    push(&bytes, opcode);
+    pushImm(&bytes, imm);
+    return bytes;
+}
+
+func mov(r: u8, imm: u64) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    modPrefix(&bytes, r);
+    let opcode = (('\xb8' as u8) + (r % 8)) as char;
+    push(&bytes, opcode);
+    pushImm(&bytes, imm);
+    return bytes;
+}
+
+func push(reg: u8) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    push(&bytes, '\xFF');
+    modRM(&bytes, ADDR_REG, 6, reg);
+    return bytes;
+}
+
+func pop(reg: u8) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    push(&bytes, '\x8F');
+    modRM(&bytes, ADDR_REG, 0, reg);
+    return bytes;
+}
+
+func mov(r: u8, offset: u32, imm: u64) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    extend(&bytes, &mov(RBX, imm));
+    assert(offset < 256, "only single byte offset for now");
+    push(&bytes, '\x48', '\x89', '\x5C', '\x24');
+    push(&bytes, offset as char);
+    return bytes;
+}
+
+func mov(r: u8, imm: f32) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    extend(&bytes, &mov(RAX, *(&imm as &u32)));
+    push(&bytes, '\x66', '\x0F', '\x6E');
+    modRM(&bytes, ADDR_REG, r, RAX);
+    return bytes;
+}
+
+func mov(r: u8, imm: f64) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    extend(&bytes, &mov(RAX, *(&imm as &u64)));
+    push(&bytes, '\x66', '\x48', '\x0F', '\x6E');
+    modRM(&bytes, ADDR_REG, r, RAX);
+    return bytes;
+}
+
+func add(r: u8, imm: u32) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    modPrefix(&bytes, r);
+    push(&bytes, '\x81');
+    modRM(&bytes, ADDR_REG, 0, r);
+    pushImm(&bytes, imm);
+    return bytes;
+}
+
+func sub(r: u8, imm: u32) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    modPrefix(&bytes, r);
+    push(&bytes, '\x81');
+    modRM(&bytes, ADDR_REG, 5, r);
+    pushImm(&bytes, imm);
+    return bytes;
+}
+
+func call(r: u8) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    push(&bytes, '\xFF');
+    modRM(&bytes, ADDR_REG, 2, r);
+    return bytes;
+}
+
+func push(val: u64) -> ByteBuffer {
+    let bytes: ByteBuffer = blank;
+    extend(&bytes, &mov(RAX, val));
+    push(&bytes, '\xFF');
+    modRM(&bytes, ADDR_REG, 6, RAX);
+    return bytes;
+}
+
+struct Function {
+    run: func () -> u64;
+    size: usize;
+}
+
+func free(fn: Function) {
+    if (!VirtualFree(fn.run as Any, fn.size, 16384)) {
+        printf("warning: Could not free function at %p\n", fn.run);
+    }
+}
+
+func compileFunctionCall(fn: Any, ret: u8, args: &ValueList) -> Function {
+    let buf: ByteBuffer = blank;
+    // push(&buf, '\xf1');
+    extend(&buf, &push(RBP));
+    extend(&buf, &mov(RBP, RSP));
+    for (let i: usize = 0; i < args.length; i = i + 1) {
+        let v = args.elements[i];
+        if (i >= 4) {
+            if (v.kind == U64) {
+                extend(&buf, &mov(RSP, 32 + 8 * (i - 4) as u32, v.u64));
+            } else if (v.kind == F64) {
+                extend(&buf, &mov(RSP, 32 + 8 * (i - 4) as u32, *(&v.f64 as &u64)));
+            } else {
+                unreachable("yo momma so fat, she caused my bits to flip");
+            }
+        } else {
+            if (v.kind == U64) {
+                extend(&buf, &mov(ARGS[i][U64 as usize], v.u64));
+            } else if (v.kind == F64) {
+                extend(&buf, &mov(ARGS[i][F64 as usize], v.f64));
+            } else if (v.kind == F32) {
+                extend(&buf, &mov(ARGS[i][F64 as usize], v.f32));
+            } else {
+                unreachable("yo momma so fat, she caused another bit flop");
+            }
+        }
+    }
+    if (args.length < 4) extend(&buf, &sub(RSP, 32));
+    extend(&buf, &mov(RAX, fn as u64));
+    extend(&buf, &call(RAX));
+    if (args.length < 4) extend(&buf, &add(RSP, 32));
+    extend(&buf, &pop(RBP));
+    if (ret == U64) {
+    } else if (ret == VOID) {
+        extend(&buf, &mov(RAX, 420691337 as u32));
+    } else if (ret == F64) {
+        push(&buf, '\x66', '\x48', '\x0F', '\x7E');
+        modRM(&buf, ADDR_REG, XMM0, RAX);
+    } else if (ret == F32) {
+        push(&buf, '\x66', '\x0F', '\x7E');
+        modRM(&buf, ADDR_REG, XMM0, RAX);
+    } else {
+        unreachable("yo momma so fat, she can't even return properly");
+    }
+    push(&buf, '\xC3');
+    @os(WINDOWS) {
+        let code = VirtualAlloc(null, buf.length, 4096, 64);
+        assert(code != null, "Could not alloc some bytes sadge thx Windows");
+        memcpy(code, buf.elements, buf.length);
+        free(buf.elements);
+        return Function { run: code as func () -> u64, size: buf.length };
+    }
+    @os(LINUX) {
+        unreachable("haven't implemented mmap yet");
+    }
+}
+
+func bar(a: usize) -> usize {
+    return a;
+}
+
+func foo(a: usize, b: f64, c: usize, d: usize, e: f64, f: usize, g: f64, h: usize) -> usize {
+    assert(a == 69, "a is wrong");
+    assert(b == 420, "b is wrong");
+    assert(c == 1337, "c is wrong");
+    assert(d == 24601, "d is wrong");
+    assert(e == 12, "e is wrong");
+    assert(f == 12309213, "f is wrong");
+    assert(g == 2147483999, "g is wrong");
+    *(h as &u8) = 69;
+    return 42069;
+}
+
+func baz(a: usize, b: f64) -> usize {
+    if (a != 19) {
+        return 1;
+    }
+    if (b != 12) {
+        return 2;
+    }
+    return 0;
+}
+
+func smolTest() {
+    let args: ValueList = blank;
+    let a: u64 = 69;
+    push(&args, Value { kind: U64, u64: a });
+    let fn = compileFunctionCall(bar as Any, U64, &args);
+    let result = fn.run();
+    assert(result == a, "Smol failure: result != a");
+    printf("ayooooo\n");
+    free(args.elements);
+    free(fn);
+}
+
+func mediumTest() {
+    let args: ValueList = blank;
+    push(&args, Value { kind: U64, u64: 19 });
+    push(&args, Value { kind: F64, f64: 12 });
+    let fn = compileFunctionCall(baz as Any, U64, &args);
+    let result = fn.run();
+    assert(result == 0, "Medium failure: result != 0");
+    printf("Ayooooo\n");
+    free(args.elements);
+    free(fn);
+}
+
+func bigTest() {
+    let haystack: u8 = 0;
+    let args: ValueList = blank;
+    push(&args, Value { kind: U64, u64: 69 });
+    push(&args, Value { kind: F64, f64: 420 });
+    push(&args, Value { kind: U64, u64: 1337 });
+    push(&args, Value { kind: U64, u64: 24601 });
+    push(&args, Value { kind: F64, f64: 12 });
+    push(&args, Value { kind: U64, u64: 12309213 });
+    push(&args, Value { kind: F64, f64: 2147483999 });
+    push(&args, Value { kind: U64, u64: &haystack as u64 });
+    let fn = compileFunctionCall(foo as Any, U64, &args);
+    let result = fn.run();
+    assert(haystack == 69, "Haystack has been compromised");
+    assert(result == 42069);
+    printf("AYOOOOO\n");
+    free(args.elements);
+    free(fn);
+}
+func betterRaylib() {
+    comptime FPS: u64 = 60;
+    comptime PixelPerSecond: u32 = 300;
+    comptime RW: f32 = 100;
+    comptime RH: f32 = 100;
+    comptime WIDTH: u64 = 800;
+    comptime HEIGHT: u64 = 600;
+    let handle = dlopen("./raylib/lib/raylib.dll", 0);
+    assert(handle != null, "Could not load raylib.dll");
+    let args: ValueList = blank;
+    let title = "Hello from the JIT";
+    push(&args, Value { kind: U64, u64: WIDTH });
+    push(&args, Value { kind: U64, u64: HEIGHT });
+    push(&args, Value { kind: U64, u64: title as u64 });
+    let InitWindow = compileFunctionCall(getFunction(handle, "InitWindow"), VOID, &args);
+    free(args.elements);
+    args.length = 0;
+    InitWindow.run();
+    let WindowShouldClose = compileFunctionCall(getFunction(handle, "WindowShouldClose"), U64, &args);
+    let BeginDrawing = compileFunctionCall(getFunction(handle, "BeginDrawing"), VOID, &args);
+    let EndDrawing = compileFunctionCall(getFunction(handle, "EndDrawing"), VOID, &args);
+    push(&args, Value { kind: U64, u64: FPS });
+    let SetTargetFPS = compileFunctionCall(getFunction(handle, "SetTargetFPS"), VOID, &args);
+    args.length = 0;
+    SetTargetFPS.run();
+    // 0x181818ff
+    push(&args, Value { kind: U64, u64: 404232447 });
+    let GetColor = compileFunctionCall(getFunction(handle, "GetColor"), U64, &args);
+    args.length = 0;
+    let c = GetColor.run();
+    push(&args, Value { kind: U64, u64: c });
+    let ClearBackground = compileFunctionCall(getFunction(handle, "ClearBackground"), VOID, &args);
+    args.length = 0;
+    let GetTime = compileFunctionCall(getFunction(handle, "GetTime"), F64, &args);
+    let x: f32 = 0;
+    let y: f32 = 0;
+    let dx: f32 = 1;
+    let dy: f32 = 1;
+    while (WindowShouldClose.run() != 1) {
+        BeginDrawing.run();
+        ClearBackground.run();
+        let _dt = GetTime.run();
+        let dt = *(&_dt as &f64) as f32;
+        push(&args, Value { kind: F32, f32: (50 * dt) % 360 });
+        push(&args, Value { kind: F32, f32: 1 });
+        push(&args, Value { kind: F32, f32: 1 });
+        let ColorFromHSV = compileFunctionCall(getFunction(handle, "ColorFromHSV"), U64, &args);
+        args.length = 0;
+        let c: u64 = ColorFromHSV.run();
+        push(&args, Value { kind: U64, u64: *(&[x, y] as &u64) });
+        push(&args, Value { kind: U64, u64: *(&[RW, RH] as &u64) });
+        push(&args, Value { kind: U64, u64: c });
+        let DrawRectangleV = compileFunctionCall(getFunction(handle, "DrawRectangleV"), VOID, &args);
+        args.length = 0;
+        DrawRectangleV.run();
+        EndDrawing.run();
+        let nx = x + dx * PixelPerSecond as f32 / FPS as f32;
+        let ny = y + dy * PixelPerSecond as f32 / FPS as f32;
+        if (nx + RW >= WIDTH as f32 || nx <= 0) dx = dx * -1;
+        else x = nx;
+        if (ny + RH >= HEIGHT as f32 || ny <= 0) dy = dy * -1;
+        else y = ny;
+        free(DrawRectangleV);
+        free(ColorFromHSV);
+    }
+    free(EndDrawing);
+    free(GetColor);
+    free(GetTime);
+    free(ClearBackground);
+    free(BeginDrawing);
+    free(WindowShouldClose);
+    free(SetTargetFPS);
+    free(InitWindow);
+    free(args.elements);
+    assert(dlclose(handle) == 0, "Could not close raylib.dll");
+}
+
+
+func main(argc: i32, argv: &&char) -> i32 {
+    let tests = [
+        smolTest,
+        mediumTest,
+        bigTest,
+        betterRaylib
+    ];
+    for (let i: usize = 0; i < 4; i = i + 1) {
+        tests[i]();
+    }
+    return 0;
+}
+

--- a/small.bufo
+++ b/small.bufo
@@ -13,7 +13,7 @@ comptime foo: i32 = 2;
     e(1);
 }
 
-func foo() -> i32 {
+func fooFn() -> i32 {
     p("yes\n");
     @os(WINDOWS) return 1;
     @os(LINUX) return 2;
@@ -27,7 +27,7 @@ func main(argc: i32, argv: &&char) -> i32 {
     @os(WINDOWS) {
         if (foo != 1) return 1;
     }
-    if (foo() != 1) {
+    if (fooFn() != 1) {
         p("fuck\n");
         return 2;
     }

--- a/src/backend/LLVM/builder.bufo
+++ b/src/backend/LLVM/builder.bufo
@@ -342,21 +342,18 @@ func buildIntTruncate(this: &LLVMBuilder, val: LLVMValue, typ: LLVMType, name: S
     assert(!isNull(value), "Could not build int truncate");
     return newLLVMValueFromRef(value);
 }
-func buildCall(this: &LLVMBuilder, fn: LLVMValue, args: LLVMValueList, name: SubStr) -> LLVMValue {
+func buildCall(this: &LLVMBuilder, fn: LLVMValue, fnType: LLVMType, args: LLVMValueList, retType: LLVMType, name: SubStr) -> LLVMValue {
     trace("LLVMBuilder.buildCall");
     guardReference(this);
     assert(sizeof LLVMValue == 8);
-    let typ: LLVMType = getGlobalType(&fn);
-    assert(isFunction(&typ), "Call expected LLVMType to be a function!");
-    let ret: LLVMType = getReturnType(&typ);
     let _n: String = blank;
-    if (isVoid(&ret)) {
+    if (isVoid(&retType)) {
         // LLVM complains about named calls that return void
         _n = newStringFromStrLit("");
     } else {
         _n = toString(&name);
     }
-    let value: LLVMValueRef = LLVMBuildCall2(this.ref, typ.ref, fn.ref, args.elements as &LLVMValueRef, args.length as u32, _n.buffer);
+    let value: LLVMValueRef = LLVMBuildCall2(this.ref, fnType.ref, fn.ref, args.elements as &LLVMValueRef, args.length as u32, _n.buffer);
     drop(&_n);
     clear(&args);
     assert(!isNull(value), "Could not build call");

--- a/src/backend/codegen_llvm.bufo
+++ b/src/backend/codegen_llvm.bufo
@@ -120,7 +120,7 @@ func generateEntryPoint(this: &LLVMCodegen) -> bool {
     let args: LLVMValueList = blank;
     push(&args, getNthParam(&main, 0));
     push(&args, getNthParam(&main, 1));
-    let v: LLVMValue = buildCall(&this.llvmBuilder, mainFunc, args, newSubStrOfStrLit("entry"));
+    let v: LLVMValue = buildCall(&this.llvmBuilder, mainFunc, retFnType, args, retType, newSubStrOfStrLit("entry"));
     buildReturn(&this.llvmBuilder, v);
     return true;
 }
@@ -141,22 +141,9 @@ func generateGlobal(this: &LLVMCodegen, global: &IRFunc) -> bool {
 
 func generateLLVMFunctionHeader(this: &LLVMCodegen, irFunc: &IRFunc) {
     let llvmFunc: LLVMValue = blank;
-    let params: LLVMTypeList = blank;
     let function: &ParsedFuncDecl = getFuncNode(irFunc);
     let typeDecl: &ParsedTypeNode = at(&typeNodes, function.retTypeID);
-    let retType = at(&types, getType(&typeDecl.typeState));
-    if (getSize(retType) > 8) {
-        retType = at(&types, intoPointer(retType));
-        push(&params, prepareParameter(this, retType));
-    }
-    for (let i: usize = 0; i < function.params.paramLength; i = i + 1) {
-        let tDecl: &ParsedTypeNode = at(&typeNodes, getTypeAtIndex(&function.params, i));
-        let t: &Type = at(&types, getType(&tDecl.typeState));
-        push(&params, prepareParameter(this, t));
-    }
-    let isVarArg = function.params.isVarArg;
-    let llvmType: LLVMType = prepareReturnType(this, retType);
-    let llvmFuncType: LLVMType = intoFunctionType(&llvmType, params, isVarArg);
+    let llvmFuncType = generateLLVMFunctionType(this, at(&types, getType(&function.typeState)));
     let llvmFuncValue: LLVMValue = addFunction(&this.llvmModule, asSubStr(&irFunc.name), llvmFuncType);
     if (hasAttribute(irFunc, ATTR_NORETURN)) {
         let id = LLVMGetEnumAttributeKindForName("noreturn", 8 /* sizeof "noreturn" */);
@@ -485,8 +472,7 @@ func generateLLVMInstr(
         let rhsVal: LLVMValue = asLLVM(at(regs, instr.op1.i), "LLVM Bitwise Xor");
         return buildXor(&this.llvmBuilder, lhsVal, rhsVal, newSubStrOfStrLit("bxor"));
     } else if (instr.kind == INSTR_CALL) {
-        let called: &IRFunc = at(&this.irGen.functions, instr.src.i);
-        let calledFunc: LLVMValue = getFunction(&this.llvmModule, asSubStr(&called.name));
+        let calledFunc: LLVMValue = asLLVM(at(regs, instr.src.i), "LLVM Call");
         assert(!isNull(calledFunc.ref), "Call tried to call invalid LLVMValue");
         let args: LLVMValueList = blank;
         initBlank(&args, instr.args.length);
@@ -496,7 +482,14 @@ func generateLLVMInstr(
             let argReg: &RegValue = at(regs, _a.i);
             *(at(&args, i)) = asLLVM(argReg, "LLVM Call Arg");
         }
-        return buildCall(&this.llvmBuilder, calledFunc, args, newSubStrOfStrLit("call"));
+        let base: &IRReg = getRegister(irFunc, instr.src);
+        let bt = base.typ;
+        if (isPointer(bt)) bt = getUnderlyingType(bt, true);
+        assert(isFunction(bt), "Call tried to call non-function base");
+        let reg: &IRReg = getRegister(irFunc, instr.dst);
+        let retType = generateLLVMType(this, reg.typ);
+        let fnType = generateLLVMFunctionType(this, bt);
+        return buildCall(&this.llvmBuilder, calledFunc, fnType, args, retType, newSubStrOfStrLit("call"));
     } else if (instr.kind == INSTR_COND_BR) {
         let cond: LLVMValue = asLLVM(at(regs, instr.src.i), "LLVM CondBr");
         buildCondBr(&this.llvmBuilder, cond, *at(blocks, instr.dst.i), *at(blocks, instr.op1.i));
@@ -730,25 +723,51 @@ func generateLLVMValueFromComptimeValue(this: &LLVMCodegen, typ: &Type, start: &
             let fType: &Type = at(&types, getType(&tDecl.typeState));
             getFieldOffsetAndSize(decl, i, &offset, &_size);
             let elemVal: LLVMValue = generateLLVMValueFromComptimeValue(this, fType, start + offset);
-            strukt = buildInsertValue(&this.llvmBuilder, 
-                strukt,
-                elemVal,
-                i as u32,
-                "comptime_struct_field",
-            );
+            strukt = buildInsertValue(&this.llvmBuilder, strukt, elemVal, i as u32, "comptime_struct_field");
         }
         return strukt;
     } else if (isArray(typ)) {
-        todo_with_msg("comptime to LLVM array");
+        let llvmType = generateLLVMType(this, typ);
+        let elemType = getUnderlyingType(typ, false);
+        let size = getSize(elemType);
+        let array = constZero(&llvmType);
+        for (let i: usize = 0; i < typ.arraySize; i = i + 1) {
+            let offset = size * i;
+            let elem = generateLLVMValueFromComptimeValue(this, elemType, start + offset);
+            array = buildInsertValue(&this.llvmBuilder, array, elem, i as u32, "comptime_array_elem");
+        }
+        return array;
     } else if (isPointer(typ)) {
         let underlying: &Type = getUnderlyingType(typ, false);
         if (isChar(underlying)) {
             return buildGlobalStringPtr(&this.llvmBuilder, *(start as &usize) as &char, newSubStrOfStrLit("comptime_str"));
         }
         todo_with_msg("comptime to LLVM pointer");
+    } else if (isFunction(typ)) {
+        let id: usize = *(start as &usize);
+        return at(&this.irGen.functions, id).llvmFunc;
     } else {
         unreachable("Exhaustive handling in generateLLVMValueFromComptime");
     }
+}
+
+func generateLLVMFunctionType(this: &LLVMCodegen, typ: &Type) -> LLVMType {
+    trace("LLVMCodegen.generateLLVMFunctionType");
+    assert(isFunction(typ), "generateLLVMFunctionType called on non function");
+    let params: LLVMTypeList = blank;
+    let retType = at(&types, typ.typeIndex);
+    if (getSize(retType) > 8) {
+        retType = at(&types, intoPointer(retType));
+        push(&params, prepareParameter(this, retType));
+    }
+    for (let i: usize = 0; i < typ.fnParams.length; i = i + 1) {
+        let t: &Type = at(&types, getType(getParam(typ, i)));
+        push(&params, prepareParameter(this, t));
+    }
+    let isVarArg = isVariadic(typ);
+    let llvmType: LLVMType = prepareReturnType(this, retType);
+    let llvmFuncType: LLVMType = intoFunctionType(&llvmType, params, isVarArg);
+    return llvmFuncType;
 }
 
 func generateLLVMType(this: &LLVMCodegen, typ: &Type) -> LLVMType {

--- a/src/backend/codegen_llvm.bufo
+++ b/src/backend/codegen_llvm.bufo
@@ -314,6 +314,9 @@ func generateLLVMInstr(
             buildStore(&this.llvmBuilder, dstVal, srcVal);
         }
         return dstVal;
+    } else if (instr.kind == INSTR_LOAD_FUNCTION_PTR) {
+        let called: &IRFunc = at(&this.irGen.functions, instr.src.i);
+        return called.llvmFunc;
     } else if (instr.kind == INSTR_LOAD) {
         let typ: &Type = getRegister(irFunc, instr.dst).typ;
         let dstTyp: LLVMType = generateLLVMType(this, typ);
@@ -771,6 +774,9 @@ func generateLLVMType(this: &LLVMCodegen, typ: &Type) -> LLVMType {
             todo_with_msg("generate primitive type");
         }
     } else if (isPointer(typ)) {
+        let t: LLVMType = createIntegerType(&this.llvmContext, 64);
+        return intoPointerType(&t);
+    } else if (isFunction(typ)) {
         let t: LLVMType = createIntegerType(&this.llvmContext, 64);
         return intoPointerType(&t);
     } else if (isArray(typ)) {

--- a/src/backend/interp.bufo
+++ b/src/backend/interp.bufo
@@ -123,6 +123,16 @@ func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &Re
         };
         popArgument(this, getRegStackPointer(this, &dst), size);
         return dst;
+    } else if (instr.kind == INSTR_LOAD_FUNCTION_PTR) {
+        let fReg: &IRReg = getRegister(irFunc, instr.dst);
+        assert(isFunction(fReg.typ), "LoadFunctionPtr got non-function");
+        let reg: InterpReg = InterpReg {
+            offset: fReg.offset,
+            size: 8,
+        };
+        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+        *(regStackLoc as &usize) = instr.src.i;
+        return reg;
     } else if (instr.kind == INSTR_LOAD) {
         // dst: reg,
         // src: ptr,
@@ -273,6 +283,14 @@ func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &Re
         };
         memset(getRegStackPointer(this, &dst), 0, dst.size);
         return dst;
+    } else if (instr.kind == INSTR_CREATE_ARRAY) {
+        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+        let dst: InterpReg = InterpReg {
+            offset: dstReg.offset,
+            size: getSize(dstReg.typ),
+        };
+        memset(getRegStackPointer(this, &dst), 0, dst.size);
+        return dst;
     } else if (instr.kind == INSTR_CREATE_STRUCT) {
         let dstReg: &IRReg = getRegister(irFunc, instr.dst);
         let dst: InterpReg = InterpReg {
@@ -301,7 +319,8 @@ func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &Re
         // op1: blank,
         // args: args,
         let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let calledFunc: &IRFunc = at(&this.irGen.functions, instr.src.i);
+        let id = *(getRegStackPointer(this, &asInterp(at(regs, instr.src.i), "Call")) as &usize);
+        let calledFunc: &IRFunc = at(&this.irGen.functions, id);
         let argSize: usize = this.argStackLength;
         let stackStart: &u8 = this.realStackStart;
         let regStackStart: &u8 = this.regStackStart;
@@ -336,7 +355,11 @@ func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &Re
         let dstStart: &u8 = getRegStackPointer(this, &dst);
         let t: &Type = dstReg.typ;
         if (isArray(t)) {
-            todo_with_msg("InsertValue Array");
+            let ut = getUnderlyingType(t, false);
+            let valReg: InterpReg = asInterp(at(regs, instr.op1.i), "Interp InsertValue Array");
+            let size = getSize(ut);
+            let offset = instr.src.i * size;
+            memcpy(dstStart + offset, getRegStackPointer(this, &valReg), size);
         } else if (isStruct(t)) {
             let s: &ParsedStructDecl = at(&structDecls, t.typeIndex);
             let offset: usize = 0;
@@ -345,10 +368,10 @@ func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &Re
             let valReg: InterpReg = asInterp(at(regs, instr.op1.i), "Interp InsertValue Struct");
             assert(valReg.size == fieldSize, "field size mismatch in Interp InsertValue");
             memcpy(dstStart + offset, getRegStackPointer(this, &valReg), fieldSize);
-            return dst;
         } else {
             unreachable("Interp InsertValue expected Array or Struct");
         }
+        return dst;
     } else if (instr.kind == INSTR_INT_ADD) {
         // OPT: Specialized 8bit, 16bit, etc. variations
         let lhs: &RegValue = at(regs, instr.src.i);

--- a/src/backend/interp.bufo
+++ b/src/backend/interp.bufo
@@ -75,6 +75,983 @@ func popArgument(this: &IRInterp, start: &u8, size: usize) {
     this.argStackLength = this.argStackLength - size;
     memcpy(start, this.argStack + this.argStackLength, size);
 }
+
+let instrFns = [
+    evaluateNotImplemented,     // INSTR_INVALID
+    evaluateAlloca,             // INSTR_ALLOCA
+    evaluateGetParam,           // INSTR_GET_PARAM
+    evaluateStore,              // INSTR_STORE
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateFetchComptimeValue, // INSTR_FETCH_COMPTIME_VALUE
+    evaluateLoadFunctionPtr,    // INSTR_LOAD_FUNCTION_PTR
+    evaluateLoad,               // INSTR_LOAD
+    evaluateMove,               // INSTR_MOVE
+    evaluateInstrCall,          // INSTR_CALL
+    evaluateReturnExpr,         // INSTR_RETURN_EXPR
+    evaluateReturnVoid,         // INSTR_RETURN_VOID
+    evaluateLoadString,         // INSTR_LOAD_STRING
+    evaluateLoadBool,           // INSTR_LOAD_BOOL
+    evaluateLoadI8,             // INSTR_LOAD_I8
+    evaluateLoadU8,             // INSTR_LOAD_U8
+    evaluateLoadI16,            // INSTR_LOAD_I16
+    evaluateLoadU16,            // INSTR_LOAD_U16
+    evaluateLoadI32,            // INSTR_LOAD_I32
+    evaluateLoadU32,            // INSTR_LOAD_U32
+    evaluateNotImplemented,
+    evaluateLoadU64,            // INSTR_LOAD_U64
+    evaluateLoadNull,           // INSTR_LOAD_NULL
+    evaluateLoadF32,            // INSTR_LOAD_F32
+    evaluateLoadF64,            // INSTR_LOAD_F64
+    evaluateLoadBlank,          // INSTR_LOAD_BLANK
+    evaluateCondBr,             // INSTR_COND_BR
+    evaluateBr,                 // INSTR_BR
+    evaluateIntAdd,             // INSTR_INT_ADD
+    evaluateIntSub,             // INSTR_INT_SUB
+    evaluateIntMul,             // INSTR_INT_MUL
+    evaluateNotImplemented,     // INSTR_INT_DIV
+    evaluateIntMod,             // INSTR_INT_MOD
+    evaluateIntCmpEqAndNeq,     // INSTR_INT_CMP_EQ
+    evaluateIntCmpEqAndNeq,     // INSTR_INT_CMP_NEQ
+    evaluateIntCmpGtAndLte,     // INSTR_INT_CMP_GT
+    evaluateIntCmpLtAndGte,     // INSTR_INT_CMP_GTE
+    evaluateIntCmpLtAndGte,     // INSTR_INT_CMP_LT
+    evaluateIntCmpGtAndLte,     // INSTR_INT_CMP_LTE
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateFloatDiv,           // INSTR_FLOAT_DIV
+    evaluateNotImplemented,
+    evaluateFloatCmpEqAndNeq,   // INSTR_FLOAT_CMP_EQ
+    evaluateFloatCmpEqAndNeq,   // INSTR_FLOAT_CMP_NEQ
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateLogicalNot,         // INSTR_LOGICAL_NOT
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateInsertValue,        // INSTR_INSERT_VALUE
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateNotImplemented,
+    evaluateIntToF32,           // INSTR_INT_TO_F32
+    evaluateNotImplemented,
+    evaluateF32ToInt,           // INSTR_F32_TO_INT
+    evaluateF64ToInt,           // INSTR_F64_TO_INT
+    evaluateF32ToF64,           // INSTR_F32_TO_F64
+    evaluateF64ToF32,           // INSTR_F64_TO_F32
+    evaluateCreateArray,        // INSTR_CREATE_ARRAY
+    evaluateCreateStruct,       // INSTR_CREATE_STRUCT
+    evaluatePtrToInt,           // INSTR_PTR_TO_INT
+    evaluateIntToPtr,           // INSTR_INT_TO_PTR
+    evaluateGetFieldPtr,        // INSTR_GET_FIELD_PTR
+    evaluateNotImplemented,     // INSTR_GET_ELEMENT_PTR
+    evaluateNotImplemented,     // INSTR_UNREACHABLE
+];
+func evaluateNotImplemented(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    printf("%s: ", toString(&instr.span).buffer);
+    dump(instr);
+    unreachable("Not implemented");
+}
+func evaluateAlloca(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateAlloca");
+    // dst: dst,
+    // src: RegIndex { i: size },
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isPointer(fReg.typ), "Alloca got non-pointer");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    *(getRegStackPointer(this, &reg) as &usize) = advanceRealStack(this, instr.span, instr.src.i) as usize;
+    return reg;
+}
+func evaluateGetParam(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateGetParam");
+    let size: usize = instr.op1.i;
+    assert(size <= 8, "Interp: Expected small size for GetParam");
+    let dst: InterpReg = InterpReg {
+        offset: getRegister(irFunc, instr.dst).offset,
+        size: size,
+    };
+    popArgument(this, getRegStackPointer(this, &dst), size);
+    return dst;
+}
+func evaluateStore(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateStore");
+    // dst: ptr,
+    // src: val,
+    let dst: &IRReg = getRegister(irFunc, instr.dst);
+    let src: &RegValue = at(regs, instr.src.i);
+    assert(isPointer(dst.typ), "Store expected Ptr Dst");
+    let dstReg: InterpReg = InterpReg {
+        offset: dst.offset,
+        size: getSize(dst.typ),
+    };
+    let srcReg: InterpReg = asInterp(src, "Store src");
+    let srcLoc: &u8 = getRegStackPointer(this, &srcReg);
+    let dstLoc: &u8 = *(getRegStackPointer(this, &dstReg) as &usize) as &u8;
+    memcpy(dstLoc, srcLoc, srcReg.size);
+    return dstReg;
+}
+func evaluateFetchComptimeValue(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateFetchComptimeValue");
+    if (instr.op1.i == 1) {
+        // Global fetch
+        let fReg = getRegister(irFunc, instr.dst);
+        let ptr = getGlobalPointer(this, &asInterp(at(this.globalRegisters, instr.src.i), "Interp FetchComptimeValue"));
+        let size = getSize(fReg.typ);
+        let reg = InterpReg {
+            offset: fReg.offset,
+            size: size,
+        };
+        memcpy(getRegStackPointer(this, &reg), ptr, size);
+        return reg;
+    } else {
+        // Local fetch
+        // noop in interpreter
+        return asInterp(at(regs, instr.src.i), "Interp FetchComptimeValue");
+    }
+}
+func evaluateLoadFunctionPtr(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadFunctionPtr");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isFunction(fReg.typ), "LoadFunctionPtr got non-function");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &usize) = instr.src.i;
+    return reg;
+}
+func evaluateLoad(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoad");
+    let dst: &IRReg = getRegister(irFunc, instr.dst);
+    let src: &RegValue = at(regs, instr.src.i);
+    let srcReg: InterpReg =  asInterp(src, "Load src");
+    assert(srcReg.size == 8, "Load expected Ptr Src");
+    let dstReg: InterpReg = InterpReg {
+        offset: dst.offset,
+        size: getSize(dst.typ),
+    };
+    let srcLoc: &u8 = *(getRegStackPointer(this, &srcReg) as &usize) as &u8;
+    let dstLoc: &u8 = getRegStackPointer(this, &dstReg);
+    memcpy(dstLoc, srcLoc, dstReg.size);
+    return dstReg;
+}
+func evaluateMove(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateMove");
+    let dst: &IRReg = getRegister(irFunc, instr.dst);
+    let src: &RegValue = at(regs, instr.src.i);
+    let srcReg: InterpReg =  asInterp(src, "Interp Move src");
+    let dstReg: InterpReg = InterpReg {
+        offset: dst.offset,
+        size: getSize(dst.typ),
+    };
+    let srcLoc: &u8 = getRegStackPointer(this, &srcReg);
+    let dstLoc: &u8 = getRegStackPointer(this, &dstReg);
+    memcpy(dstLoc, srcLoc, dstReg.size);
+    return dstReg;
+}
+func evaluateInstrCall(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateInstrCall");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let id = *(getRegStackPointer(this, &asInterp(at(regs, instr.src.i), "Call")) as &usize);
+    let calledFunc: &IRFunc = at(&this.irGen.functions, id);
+    let argSize: usize = this.argStackLength;
+    let stackStart: &u8 = this.realStackStart;
+    let regStackStart: &u8 = this.regStackStart;
+    for (let _i: usize = 0; _i < instr.args.length; _i = _i + 1) {
+        let i: usize = instr.args.length - _i - 1;
+        let reg: &RegValue = at(regs, at(&instr.args, i).i);
+        let arg: InterpReg = asInterp(reg, "call arg");
+        pushArgument(this, getRegStackPointer(this, &arg), arg.size);
+    }
+    let regs: RegValueList = blank;
+    initBlank(&regs, calledFunc.registers.length);
+    evaluateCall(this, instr.span, calledFunc, &regs);
+    let size: usize = getSize(dstReg.typ);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: size,
+    };
+    popArgument(this, getRegStackPointer(this, &dst), size);
+    assert(argSize == this.argStackLength, "Imbalanced argument stack after calling IRInterp.evaluateCall");
+    assert(stackStart == this.realStackStart, "Imbalanced real stack after calling IRInterp.evaluateCall");
+    assert(regStackStart == this.regStackStart, "Imbalanced reg stack after calling IRInterp.evaluateCall");
+    return dst;
+}
+func evaluateReturnExpr(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateReturnExpr");
+    let expr: &RegValue = &*at(regs, instr.src.i);
+    let rExpr: InterpReg =  asInterp(expr, "ReturnExpr");
+    pushArgument(this, getRegStackPointer(this, &rExpr), rExpr.size);
+    return blank;
+}
+
+func evaluateReturnVoid(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateReturnVoid");
+    return blank;
+}
+
+func evaluateLoadString(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadString");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isPointer(fReg.typ), "LoadString expected Ptr");
+    assert(isChar(getUnderlyingType(fReg.typ, false)), "LoadString expected Ptr to Char");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &usize) = instr.src.i;
+    return reg;
+}
+func evaluateLoadBool(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadBool");
+    let isTrue: u8 = instr.src.i as u8;
+    assert(isTrue == 0 || isTrue == 1, "LoadBool expected 0 or 1");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 1,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &u8) = isTrue;
+    return reg;
+}
+
+func evaluateLoadI8(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadI8");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ), "LoadI8 got non-int");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 1,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &i8) = instr.src.i as i8;
+    return reg;
+}
+func evaluateLoadU8(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadU8");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ) || isChar(fReg.typ), "LoadU8 got non-int non-char");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 1,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &u8) = instr.src.i as u8;
+    return reg;
+}
+func evaluateLoadI16(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadI16");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ), "LoadI16 got non-int");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 2,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &i16) = instr.src.i as i16;
+    return reg;
+}
+
+func evaluateLoadU16(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadU16");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ), "LoadU16 got non-int");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 2,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &u16) = instr.src.i as u16;
+    return reg;
+}
+func evaluateLoadI32(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadI32");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ), "LoadI32 got non-int");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 4,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &i32) = instr.src.i as i32;
+    return reg;
+}
+func evaluateLoadU32(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadU32");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ), "LoadU32 got non-int");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 4,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &u32) = instr.src.i as u32;
+    return reg;
+}
+func evaluateLoadU64(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadU64");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isInteger(fReg.typ), "LoadU64 got non-int");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &usize) = instr.src.i;
+    return reg;
+}
+
+func evaluateLoadNull(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadNull");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isPointer(fReg.typ), "LoadNull got non-ptr");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &usize) = 0;
+    return reg;
+}
+func evaluateLoadF32(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadF32");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isFloat(fReg.typ), "LoadF32 got non-float");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 4,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &f32) = *(&instr.src.i as &f32);
+    return reg;
+}
+
+func evaluateLoadF64(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadF64");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    assert(isFloat(fReg.typ), "LoadF64 got non-float");
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    *(regStackLoc as &f64) = *(&instr.src.i as &f64);
+    return reg;
+}
+
+func evaluateLoadBlank(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLoadBlank");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: getSize(dstReg.typ),
+    };
+    memset(getRegStackPointer(this, &dst), 0, dst.size);
+    return dst;
+}
+func evaluateCondBr(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateCondBr");
+    let cond: &RegValue = at(regs, instr.src.i);
+    let rCond: InterpReg = asInterp(cond, "CondBr");
+    assert(rCond.size == 1, "comptime CondBr expected single byte Cond");
+    let condLoc: &u8 = getRegStackPointer(this, &rCond);
+    let v: u8 = *condLoc;
+    assert(v == 0 || v == 1, "condition is not 0 or 1");
+    let id: usize = 0;
+    if (v == 1) {
+        id = instr.dst.i;
+    } else {
+        id = instr.op1.i;
+    }
+    return InterpReg { offset: id, size: 1 };
+}
+func evaluateBr(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateBr");
+    return InterpReg { offset: instr.dst.i, size: 1 };
+}
+func evaluateIntAdd(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntAdd");
+    // OPT: Specialized 8bit, 16bit, etc. variations
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg = asInterp(lhs, "AddInt LHS");
+    let rRhs: InterpReg = asInterp(rhs, "AddInt RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let signed: bool = isSignedInteger(t1);
+    let s1: usize = rLhs.size;
+    let s2: usize = rRhs.size;
+    assert(s1 == s2, "AddInt expected LHS and RHS to be the same size");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: s1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    if (s1 == 1) {
+        if (signed) *(start as &i8) = *(lhsStart as &i8) + *(rhsStart as &i8);
+        else *(start as &u8) = *(lhsStart as &u8) + *(rhsStart as &u8);
+    } else if (s1 == 2) {
+        if (signed) *(start as &i16) = *(lhsStart as &i16) + *(rhsStart as &i16);
+        else *(start as &u16) = *(lhsStart as &u16) + *(rhsStart as &u16);
+    } else if (s1 == 4) {
+        if (signed) *(start as &i32) = *(lhsStart as &i32) + *(rhsStart as &i32);
+        else *(start as &u32) = *(lhsStart as &u32) + *(rhsStart as &u32);
+    } else if (s1 == 8) {
+        if (signed) *(start as &i64) = *(lhsStart as &i64) + *(rhsStart as &i64);
+        else *(start as &u64) = *(lhsStart as &u64) + *(rhsStart as &u64);
+    } else {
+        unreachable("int add with sus bitsize");
+    }
+    return dst;
+}
+func evaluateIntSub(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntSub");
+    // OPT: Specialized 8bit, 16bit, etc. variations
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "SubInt LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "SubInt RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let signed: bool = isSignedInteger(t1);
+    let s1: usize = rLhs.size;
+    let s2: usize = rRhs.size;
+    assert(s1 == s2, "SubInt expected LHS and RHS to be the same size");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: s1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    if (s1 == 1) {
+        if (signed) *(start as &i8) = *(lhsStart as &i8) - *(rhsStart as &i8);
+        else *(start as &u8) = *(lhsStart as &u8) - *(rhsStart as &u8);
+    } else if (s1 == 2) {
+        if (signed) *(start as &i16) = *(lhsStart as &i16) - *(rhsStart as &i16);
+        else *(start as &u16) = *(lhsStart as &u16) - *(rhsStart as &u16);
+    } else if (s1 == 4) {
+        if (signed) *(start as &i32) = *(lhsStart as &i32) - *(rhsStart as &i32);
+        else *(start as &u32) = *(lhsStart as &u32) - *(rhsStart as &u32);
+    } else if (s1 == 8) {
+        if (signed) *(start as &i64) = *(lhsStart as &i64) - *(rhsStart as &i64);
+        else *(start as &u64) = *(lhsStart as &u64) - *(rhsStart as &u64);
+    } else {
+        unreachable("int add with sus bitsize");
+    }
+    return dst;
+}
+
+func evaluateIntMul(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntMul");
+    // OPT: Specialized 8bit, 16bit, etc. variations
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "MulInt LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "MulInt RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let signed: bool = isSignedInteger(t1);
+    let s1: usize = rLhs.size;
+    let s2: usize = rRhs.size;
+    assert(s1 == s2, "MulInt expected LHS and RHS to be the same size");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: s1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    if (s1 == 1) {
+        if (signed) *(start as &i8) = *(lhsStart as &i8) * *(rhsStart as &i8);
+        else *(start as &u8) = *(lhsStart as &u8) * *(rhsStart as &u8);
+    } else if (s1 == 2) {
+        if (signed) *(start as &i16) = *(lhsStart as &i16) * *(rhsStart as &i16);
+        else *(start as &u16) = *(lhsStart as &u16) * *(rhsStart as &u16);
+    } else if (s1 == 4) {
+        if (signed) *(start as &i32) = *(lhsStart as &i32) * *(rhsStart as &i32);
+        else *(start as &u32) = *(lhsStart as &u32) * *(rhsStart as &u32);
+    } else if (s1 == 8) {
+        if (signed) *(start as &i64) = *(lhsStart as &i64) * *(rhsStart as &i64);
+        else *(start as &u64) = *(lhsStart as &u64) * *(rhsStart as &u64);
+    } else {
+        unreachable("int mul with sus bitsize");
+    }
+    return dst;
+}
+func evaluateIntMod(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntMod");
+    // OPT: Specialized 8bit, 16bit, etc. variations
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "ModInt LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "ModInt RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let signed: bool = isSignedInteger(t1);
+    let s1: usize = rLhs.size;
+    let s2: usize = rRhs.size;
+    assert(s1 == s2, "ModInt expected LHS and RHS to be the same size");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: s1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    if (s1 == 1) {
+        if (signed) *(start as &i8) = *(lhsStart as &i8) % *(rhsStart as &i8);
+        else *(start as &u8) = *(lhsStart as &u8) % *(rhsStart as &u8);
+    } else if (s1 == 2) {
+        if (signed) *(start as &i16) = *(lhsStart as &i16) % *(rhsStart as &i16);
+        else *(start as &u16) = *(lhsStart as &u16) % *(rhsStart as &u16);
+    } else if (s1 == 4) {
+        if (signed) *(start as &i32) = *(lhsStart as &i32) % *(rhsStart as &i32);
+        else *(start as &u32) = *(lhsStart as &u32) % *(rhsStart as &u32);
+    } else if (s1 == 8) {
+        if (signed) *(start as &i64) = *(lhsStart as &i64) % *(rhsStart as &i64);
+        else *(start as &u64) = *(lhsStart as &u64) % *(rhsStart as &u64);
+    } else {
+        unreachable("int mod with sus bitsize");
+    }
+    return dst;
+}
+func evaluateIntCmpEqAndNeq(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntCmpEqAndNeq");
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "ICmpNeq/ICmpEq LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "ICmpNeq/ICmpEq RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let t2: &Type = getRegister(irFunc, instr.op1).typ;
+    let s1: usize = getSize(t1);
+    let s2: usize = getSize(t2);
+    assert(s1 == s2, "ICmpNeq/ICmpEq got differently sized operands");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    let eq: bool = false;
+    if (isInteger(t1) || isPointer(t1) || isChar(t1)) {
+        let signed: bool = isSignedInteger(t1);
+        if (s1 == 1) {
+            if (signed) eq = *(lhsStart as &i8) == *(rhsStart as &i8);
+            else eq = *(lhsStart as &u8) == *(rhsStart as &u8);
+        } else if (s1 == 2) {
+            if (signed) eq = *(lhsStart as &i16) == *(rhsStart as &i16);
+            else eq = *(lhsStart as &u16) == *(rhsStart as &u16);
+        } else if (s1 == 4) {
+            if (signed) eq = *(lhsStart as &i32) == *(rhsStart as &i32);
+            else eq = *(lhsStart as &u32) == *(rhsStart as &u32);
+        } else if (s1 == 8) {
+            if (signed) eq = *(lhsStart as &i64) == *(rhsStart as &i64);
+            else eq = *(lhsStart as &u64) == *(rhsStart as &u64);
+        } else {
+            unreachable("int cmp with sus bitsize");
+        }
+    } else {
+        unreachable("Interp ICmpEq/ICmpNeq on non-int");
+    }
+    let r: u8 = 0;
+    if (eq) r = 1;
+    if (instr.kind == INSTR_INT_CMP_NEQ) r = 1 - r;
+    *start = r;
+    return dst;
+}
+func evaluateIntCmpGtAndLte(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntCmpGtAndLte");
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "ICmpGt/ICmpLte LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "ICmpGt/ICmpLte RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let t2: &Type = getRegister(irFunc, instr.op1).typ;
+    let s1: usize = getSize(t1);
+    let s2: usize = getSize(t2);
+    assert(s1 == s2, "ICmpGt/ICmpLte got differently sized operands");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    let gt: bool = false;
+    if (isInteger(t1)) {
+        let signed: bool = isSignedInteger(t1);
+        if (s1 == 1) {
+            if (signed) gt = *(lhsStart as &i8) > *(rhsStart as &i8);
+            else gt = *(lhsStart as &u8) > *(rhsStart as &u8);
+        } else if (s1 == 2) {
+            if (signed) gt = *(lhsStart as &i16) > *(rhsStart as &i16);
+            else gt = *(lhsStart as &u16) > *(rhsStart as &u16);
+        } else if (s1 == 4) {
+            if (signed) gt = *(lhsStart as &i32) > *(rhsStart as &i32);
+            else gt = *(lhsStart as &u32) > *(rhsStart as &u32);
+        } else if (s1 == 8) {
+            if (signed) gt = *(lhsStart as &i64) > *(rhsStart as &i64);
+            else gt = *(lhsStart as &u64) > *(rhsStart as &u64);
+        } else {
+            unreachable("int cmpgt with sus bitsize");
+        }
+    } else {
+        unreachable("Interp ICmpGt/ICmpLte on non-int");
+    }
+    let r: u8 = 0;
+    if (gt) r = 1;
+    if (instr.kind == INSTR_INT_CMP_LTE) r = 1 - r;
+    *start = r;
+    return dst;
+}
+func evaluateIntCmpLtAndGte(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntCmpLtAndGte");
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "ICmpLt/ICmpGte LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "ICmpLt/ICmpGte RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let t2: &Type = getRegister(irFunc, instr.op1).typ;
+    let s1: usize = getSize(t1);
+    let s2: usize = getSize(t2);
+    assert(s1 == s2, "ICmpLt/ICmpGte got differently sized operands");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    let gt: bool = false;
+    if (isInteger(t1)) {
+        let signed: bool = isSignedInteger(t1);
+        if (s1 == 1) {
+            if (signed) gt = *(lhsStart as &i8) < *(rhsStart as &i8);
+            else gt = *(lhsStart as &u8) < *(rhsStart as &u8);
+        } else if (s1 == 2) {
+            if (signed) gt = *(lhsStart as &i16) < *(rhsStart as &i16);
+            else gt = *(lhsStart as &u16) < *(rhsStart as &u16);
+        } else if (s1 == 4) {
+            if (signed) gt = *(lhsStart as &i32) < *(rhsStart as &i32);
+            else gt = *(lhsStart as &u32) < *(rhsStart as &u32);
+        } else if (s1 == 8) {
+            if (signed) gt = *(lhsStart as &i64) < *(rhsStart as &i64);
+            else gt = *(lhsStart as &u64) < *(rhsStart as &u64);
+        } else {
+            unreachable("int cmpgt with sus bitsize");
+        }
+    } else {
+        unreachable("Interp ICmpGt/ICmpLte on non-int");
+    }
+    let r: u8 = 0;
+    if (gt) r = 1;
+    if (instr.kind == INSTR_INT_CMP_GTE) r = 1 - r;
+    *start = r;
+    return dst;
+}
+
+func evaluateFloatDiv(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateFloatDiv");
+    // OPT: Specialized 8bit, 16bit, etc. variations
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "FloatDiv LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "FloatDiv RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let s1: usize = rLhs.size;
+    let s2: usize = rRhs.size;
+    assert(s1 == s2, "FloatDiv expected LHS and RHS to be the same size");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: s1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    if (s1 == 4) {
+        *(start as &f32) = *(lhsStart as &f32) / *(rhsStart as &f32);
+    } else if (s1 == 8) {
+        *(start as &f64) = *(lhsStart as &f64) / *(rhsStart as &f64);
+    } else {
+        unreachable("float div with sus bitsize");
+    }
+    return dst;
+}
+func evaluateFloatCmpEqAndNeq(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateFloatCmpEqAndNeq");
+    let lhs: &RegValue = at(regs, instr.src.i);
+    let rhs: &RegValue = at(regs, instr.op1.i);
+    let rLhs: InterpReg =  asInterp(lhs, "FCmpNeq/FCmpEq LHS");
+    let rRhs: InterpReg =  asInterp(rhs, "FCmpNeq/FCmpEq RHS");
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let t2: &Type = getRegister(irFunc, instr.op1).typ;
+    let s1: usize = getSize(t1);
+    let s2: usize = getSize(t2);
+    assert(s1 == s2, "FCmpNeq/FCmpEq got differently sized operands");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 1,
+    };
+    let start: &u8 = getRegStackPointer(this, &dst);
+    let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
+    let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
+    let eq: bool = false;
+    if (isFloat(t1)) {
+        if (s1 == 4) {
+            eq = *(lhsStart as &f32) == *(rhsStart as &f32);
+        } else if (s1 == 8) {
+            eq = *(lhsStart as &f64) == *(rhsStart as &f64);
+        } else {
+            unreachable("float cmp with sus bitsize");
+        }
+    } else {
+        unreachable("Interp FCmpEq/FCmpNeq on non-float");
+    }
+    let r: u8 = 0;
+    if (eq) r = 1;
+    if (instr.kind == INSTR_FLOAT_CMP_NEQ) r = 1 - r;
+    *start = r;
+    return dst;
+}
+func evaluateLogicalNot(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateLogicalNot");
+    let src: &RegValue = at(regs, instr.src.i);
+    let rSrc: InterpReg = asInterp(src, "LNot SRC");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let t1: &Type = getRegister(irFunc, instr.src).typ;
+    let s1: usize = getSize(t1);
+    assert(s1 == 1, "Idk");
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: s1,
+    };
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let srcStart: &u8 = getRegStackPointer(this, &rSrc);
+    let val: u8 = *srcStart;
+    assert(val == 0 || val == 1, "Logical Not got non-zero non-one");
+    *dstStart = 1 - val;
+    return dst;
+}
+func evaluateInsertValue(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateInsertValue");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: getSize(dstReg.typ),
+    };
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let t: &Type = dstReg.typ;
+    if (isArray(t)) {
+        let ut = getUnderlyingType(t, false);
+        let valReg: InterpReg = asInterp(at(regs, instr.op1.i), "Interp InsertValue Array");
+        let size = getSize(ut);
+        let offset = instr.src.i * size;
+        memcpy(dstStart + offset, getRegStackPointer(this, &valReg), size);
+    } else if (isStruct(t)) {
+        let s: &ParsedStructDecl = at(&structDecls, t.typeIndex);
+        let offset: usize = 0;
+        let fieldSize: usize = 0;
+        getFieldOffsetAndSize(s, instr.src.i, &offset, &fieldSize);
+        let valReg: InterpReg = asInterp(at(regs, instr.op1.i), "Interp InsertValue Struct");
+        assert(valReg.size == fieldSize, "field size mismatch in Interp InsertValue");
+        memcpy(dstStart + offset, getRegStackPointer(this, &valReg), fieldSize);
+    } else {
+        unreachable("Interp InsertValue expected Array or Struct");
+    }
+    return dst;
+}
+func evaluateF32ToF64(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateF32ToF64");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F32ToF64");
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 8,
+    };
+    let srcStart: &u8 = getRegStackPointer(this, &src);
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let v: f32 = *(srcStart as &f32);
+    *(dstStart as &f64) = v as f64;
+    return dst;
+}
+func evaluateF64ToF32(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateF64ToF32");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F64ToF32");
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 4,
+    };
+    let srcStart: &u8 = getRegStackPointer(this, &src);
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let v: f64 = *(srcStart as &f64);
+    *(dstStart as &f32) = v as f32;
+    return dst;
+}
+func evaluateCreateArray(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateCreateArray");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: getSize(dstReg.typ),
+    };
+    memset(getRegStackPointer(this, &dst), 0, dst.size);
+    return dst;
+}
+func evaluateCreateStruct(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateCreateStruct");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: getSize(dstReg.typ),
+    };
+    memset(getRegStackPointer(this, &dst), 0, dst.size);
+    return dst;
+}
+func evaluateIntToF32(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntToF32");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp IntToF32");
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: 4,
+    };
+    let srcStart: &u8 = getRegStackPointer(this, &src);
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let t: &Type = getRegister(irFunc, instr.src).typ;
+    let signed: bool = isSignedInteger(t);
+    let s: usize = getSize(t);
+    let v: f32 = 0;
+    if (s == 1) {
+        if (signed) v = *(srcStart as &i8) as f32;
+        else v = *(srcStart as &u8) as f32;
+    } else if (s == 2) {
+        if (signed) v = *(srcStart as &i16) as f32;
+        else v = *(srcStart as &u16) as f32;
+    } else if (s == 4) {
+        if (signed) v = *(srcStart as &i32) as f32;
+        else v = *(srcStart as &u32) as f32;
+    } else if (s == 8) {
+        if (signed) v = *(srcStart as &i64) as f32;
+        else v = *(srcStart as &u64) as f32;
+    } else {
+        unreachable("Interp unexpected size in IntToF32");
+    }
+    *(dstStart as &f32) = v;
+    return dst;
+}
+func evaluateF32ToInt(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateF32ToInt");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F32ToInt");
+    let size: usize = getSize(dstReg.typ);
+    let signed: bool = isSignedInteger(dstReg.typ);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: size,
+    };
+    let srcStart: &u8 = getRegStackPointer(this, &src);
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let v: f32 = *(srcStart as &f32);
+    if (size == 1) {
+        if (signed) *(dstStart as &i8) = v as i8;
+        else *(dstStart as &u8) = v as u8;
+    } else if (size == 2) {
+        if (signed) *(dstStart as &i16) = v as i16;
+        else *(dstStart as &u16) = v as u16;
+    } else if (size == 4) {
+        if (signed) *(dstStart as &i32) = v as i32;
+        else *(dstStart as &u32) = v as u32;
+    } else if (size == 8) {
+        if (signed) *(dstStart as &i64) = v as i64;
+        else *(dstStart as &u64) = v as u64;
+    } else {
+        unreachable("Interp F32ToInt: Exhaustive handling of destinations");
+    }
+    return dst;
+}
+func evaluateF64ToInt(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateF64ToInt");
+    let dstReg: &IRReg = getRegister(irFunc, instr.dst);
+    let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F64ToInt");
+    let size: usize = getSize(dstReg.typ);
+    let signed: bool = isSignedInteger(dstReg.typ);
+    let dst: InterpReg = InterpReg {
+        offset: dstReg.offset,
+        size: size,
+    };
+    let srcStart: &u8 = getRegStackPointer(this, &src);
+    let dstStart: &u8 = getRegStackPointer(this, &dst);
+    let v: f64 = *(srcStart as &f64);
+    if (size == 1) {
+        if (signed) *(dstStart as &i8) = v as i8;
+        else *(dstStart as &u8) = v as u8;
+    } else if (size == 2) {
+        if (signed) *(dstStart as &i16) = v as i16;
+        else *(dstStart as &u16) = v as u16;
+    } else if (size == 4) {
+        if (signed) *(dstStart as &i32) = v as i32;
+        else *(dstStart as &u32) = v as u32;
+    } else if (size == 8) {
+        if (signed) *(dstStart as &i64) = v as i64;
+        else *(dstStart as &u64) = v as u64;
+    } else {
+        unreachable("Interp F64ToInt: Exhaustive handling of destinations");
+    }
+    return dst;
+}
+func evaluatePtrToInt(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluatePtrToInt");
+    // noop in interpreter
+    return asInterp(at(regs, instr.src.i), "Interp PtrToInt");
+}
+func evaluateIntToPtr(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateIntToPtr");
+    // noop in interpreter
+    return asInterp(at(regs, instr.src.i), "Interp IntToPtr");
+}
+func evaluateGetFieldPtr(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
+    trace("IRInterp.evaluateGetFieldPtr");
+    let fReg: &IRReg = getRegister(irFunc, instr.dst);
+    let fAggr: InterpReg = asInterp(at(regs, instr.src.i), "IRInterp: GetFieldPtr");
+    let t: &Type = getRegister(irFunc, instr.src).typ;
+    assert(isStructPointer(t), "IRInterp: GetFieldPtr got non-struct pointer");
+    let u: &Type = getUnderlyingType(t, false);
+    assert(isStruct(u));
+    let decl: &ParsedStructDecl = at(&structDecls, u.typeIndex);
+    let offset: usize = 0;
+    let size: usize = 0;
+    getFieldOffsetAndSize(decl, instr.op1.i, &offset, &size);
+    let reg: InterpReg = InterpReg {
+        offset: fReg.offset,
+        size: 8,
+    };
+    let regStackLoc: &u8 = getRegStackPointer(this, &reg);
+    let ptr: &u8 = getRegStackPointer(this, &fAggr);
+    *(regStackLoc as &usize) = *(ptr as &usize) + offset;
+    return reg;
+}
+
 func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &RegValueList, forcedComptime: bool) -> InterpReg {
     trace("IRInterp.evaluateSingle");
     if (!forcedComptime) {
@@ -82,807 +1059,7 @@ func evaluateSingle(this: &IRInterp, irFunc: &IRFunc, instr: &IRInstr, regs: &Re
     }
     assert(this.regStackBase < this.regStackStart + REG_STACK_SIZE, "Stack Cursor Overflow in IRInterp.evaluateSingle");
     if (PRINT_DEBUG) dump(instr);
-    if (instr.kind == INSTR_ALLOCA) {
-        // dst: dst,
-        // src: RegIndex { i: size },
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isPointer(fReg.typ), "Alloca got non-pointer");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        *(getRegStackPointer(this, &reg) as &usize) = advanceRealStack(this, instr.span, instr.src.i) as usize;
-        return reg;
-    } else if (instr.kind == INSTR_STORE) {
-        // dst: ptr,
-        // src: val,
-        let dst: &IRReg = getRegister(irFunc, instr.dst);
-        let src: &RegValue = at(regs, instr.src.i);
-        assert(isPointer(dst.typ), "Store expected Ptr Dst");
-        let dstReg: InterpReg = InterpReg {
-            offset: dst.offset,
-            size: getSize(dst.typ),
-        };
-        let srcReg: InterpReg = asInterp(src, "Store src");
-        let srcLoc: &u8 = getRegStackPointer(this, &srcReg);
-        let dstLoc: &u8 = *(getRegStackPointer(this, &dstReg) as &usize) as &u8;
-        memcpy(dstLoc, srcLoc, srcReg.size);
-        return dstReg;
-    } else if (instr.kind == INSTR_GET_PARAM) {
-        // dst: dst,
-        // src: RegIndex { i: index },
-        // op1: RegIndex { i: size },
-        // this.argStack -> top is argument
-        // size of arg -> instr.src.i
-        // param ptr -> reg[instr.dst]
-        let size: usize = instr.op1.i;
-        assert(size <= 8, "Interp: Expected small size for GetParam");
-        let dst: InterpReg = InterpReg {
-            offset: getRegister(irFunc, instr.dst).offset,
-            size: size,
-        };
-        popArgument(this, getRegStackPointer(this, &dst), size);
-        return dst;
-    } else if (instr.kind == INSTR_LOAD_FUNCTION_PTR) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isFunction(fReg.typ), "LoadFunctionPtr got non-function");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &usize) = instr.src.i;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD) {
-        // dst: reg,
-        // src: ptr,
-        let dst: &IRReg = getRegister(irFunc, instr.dst);
-        let src: &RegValue = at(regs, instr.src.i);
-        let srcReg: InterpReg =  asInterp(src, "Load src");
-        assert(srcReg.size == 8, "Load expected Ptr Src");
-        let dstReg: InterpReg = InterpReg {
-            offset: dst.offset,
-            size: getSize(dst.typ),
-        };
-        let srcLoc: &u8 = *(getRegStackPointer(this, &srcReg) as &usize) as &u8;
-        let dstLoc: &u8 = getRegStackPointer(this, &dstReg);
-        memcpy(dstLoc, srcLoc, dstReg.size);
-        return dstReg;
-    } else if (instr.kind == INSTR_MOVE) {
-        // dst: reg,
-        // src: ptr,
-        let dst: &IRReg = getRegister(irFunc, instr.dst);
-        let src: &RegValue = at(regs, instr.src.i);
-        let srcReg: InterpReg =  asInterp(src, "Interp Move src");
-        let dstReg: InterpReg = InterpReg {
-            offset: dst.offset,
-            size: getSize(dst.typ),
-        };
-        let srcLoc: &u8 = getRegStackPointer(this, &srcReg);
-        let dstLoc: &u8 = getRegStackPointer(this, &dstReg);
-        memcpy(dstLoc, srcLoc, dstReg.size);
-        return dstReg;
-    } else if (instr.kind == INSTR_LOAD_I8) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ), "LoadI8 got non-int");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 1,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &i8) = instr.src.i as i8;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_U8) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ) || isChar(fReg.typ), "LoadU8 got non-int non-char");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 1,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &u8) = instr.src.i as u8;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_I16) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ), "LoadI16 got non-int");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 2,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &i16) = instr.src.i as i16;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_U16) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ), "LoadU16 got non-int");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 2,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &u16) = instr.src.i as u16;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_I32) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ), "LoadI32 got non-int");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 4,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &i32) = instr.src.i as i32;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_U32) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ), "LoadU32 got non-int");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 4,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &u32) = instr.src.i as u32;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_I64) {
-        todo_with_msg("INSTR_LOAD_I64");
-    } else if (instr.kind == INSTR_LOAD_U64) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isInteger(fReg.typ), "LoadU64 got non-int");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &usize) = instr.src.i;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_F32) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isFloat(fReg.typ), "LoadF32 got non-float");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 4,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &f32) = *(&instr.src.i as &f32);
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_F64) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isFloat(fReg.typ), "LoadF64 got non-float");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &f64) = *(&instr.src.i as &f64);
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_BOOL) {
-        let isTrue: u8 = instr.src.i as u8;
-        assert(isTrue == 0 || isTrue == 1, "LoadBool expected 0 or 1");
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 1,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &u8) = isTrue;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_NULL) {
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isPointer(fReg.typ), "LoadNull got non-ptr");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &usize) = 0;
-        return reg;
-    } else if (instr.kind == INSTR_LOAD_BLANK) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: getSize(dstReg.typ),
-        };
-        memset(getRegStackPointer(this, &dst), 0, dst.size);
-        return dst;
-    } else if (instr.kind == INSTR_CREATE_ARRAY) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: getSize(dstReg.typ),
-        };
-        memset(getRegStackPointer(this, &dst), 0, dst.size);
-        return dst;
-    } else if (instr.kind == INSTR_CREATE_STRUCT) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: getSize(dstReg.typ),
-        };
-        memset(getRegStackPointer(this, &dst), 0, dst.size);
-        return dst;
-    } else if (instr.kind == INSTR_LOAD_STRING) {
-        // dst: dst,
-        // src: RegIndex { i: str.start as usize },
-        // op1: RegIndex { i: str.len },
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        assert(isPointer(fReg.typ), "LoadString expected Ptr");
-        assert(isChar(getUnderlyingType(fReg.typ, false)), "LoadString expected Ptr to Char");
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        *(regStackLoc as &usize) = instr.src.i;
-        return reg;
-    } else if (instr.kind == INSTR_CALL) {
-        // dst: dst,
-        // src: funcID,
-        // op1: blank,
-        // args: args,
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let id = *(getRegStackPointer(this, &asInterp(at(regs, instr.src.i), "Call")) as &usize);
-        let calledFunc: &IRFunc = at(&this.irGen.functions, id);
-        let argSize: usize = this.argStackLength;
-        let stackStart: &u8 = this.realStackStart;
-        let regStackStart: &u8 = this.regStackStart;
-        for (let _i: usize = 0; _i < instr.args.length; _i = _i + 1) {
-            let i: usize = instr.args.length - _i - 1;
-            let reg: &RegValue = at(regs, at(&instr.args, i).i);
-            let arg: InterpReg = asInterp(reg, "call arg");
-            pushArgument(this, getRegStackPointer(this, &arg), arg.size);
-        }
-        let regs: RegValueList = blank;
-        initBlank(&regs, calledFunc.registers.length);
-        evaluateCall(this, instr.span, calledFunc, &regs);
-        let size: usize = getSize(dstReg.typ);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: size,
-        };
-        popArgument(this, getRegStackPointer(this, &dst), size);
-        assert(argSize == this.argStackLength, "Imbalanced argument stack after calling IRInterp.evaluateCall");
-        assert(stackStart == this.realStackStart, "Imbalanced real stack after calling IRInterp.evaluateCall");
-        assert(regStackStart == this.regStackStart, "Imbalanced reg stack after calling IRInterp.evaluateCall");
-        return dst;
-    } else if (instr.kind == INSTR_INSERT_VALUE) {
-        // dst: aggr,
-        // src: RegIndex { i: index },
-        // op1: val,
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: getSize(dstReg.typ),
-        };
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let t: &Type = dstReg.typ;
-        if (isArray(t)) {
-            let ut = getUnderlyingType(t, false);
-            let valReg: InterpReg = asInterp(at(regs, instr.op1.i), "Interp InsertValue Array");
-            let size = getSize(ut);
-            let offset = instr.src.i * size;
-            memcpy(dstStart + offset, getRegStackPointer(this, &valReg), size);
-        } else if (isStruct(t)) {
-            let s: &ParsedStructDecl = at(&structDecls, t.typeIndex);
-            let offset: usize = 0;
-            let fieldSize: usize = 0;
-            getFieldOffsetAndSize(s, instr.src.i, &offset, &fieldSize);
-            let valReg: InterpReg = asInterp(at(regs, instr.op1.i), "Interp InsertValue Struct");
-            assert(valReg.size == fieldSize, "field size mismatch in Interp InsertValue");
-            memcpy(dstStart + offset, getRegStackPointer(this, &valReg), fieldSize);
-        } else {
-            unreachable("Interp InsertValue expected Array or Struct");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_INT_ADD) {
-        // OPT: Specialized 8bit, 16bit, etc. variations
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "AddInt LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "AddInt RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let signed: bool = isSignedInteger(t1);
-        let s1: usize = rLhs.size;
-        let s2: usize = rRhs.size;
-        assert(s1 == s2, "AddInt expected LHS and RHS to be the same size");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: s1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        if (s1 == 1) {
-            if (signed) *(start as &i8) = *(lhsStart as &i8) + *(rhsStart as &i8);
-            else *(start as &u8) = *(lhsStart as &u8) + *(rhsStart as &u8);
-        } else if (s1 == 2) {
-            if (signed) *(start as &i16) = *(lhsStart as &i16) + *(rhsStart as &i16);
-            else *(start as &u16) = *(lhsStart as &u16) + *(rhsStart as &u16);
-        } else if (s1 == 4) {
-            if (signed) *(start as &i32) = *(lhsStart as &i32) + *(rhsStart as &i32);
-            else *(start as &u32) = *(lhsStart as &u32) + *(rhsStart as &u32);
-        } else if (s1 == 8) {
-            if (signed) *(start as &i64) = *(lhsStart as &i64) + *(rhsStart as &i64);
-            else *(start as &u64) = *(lhsStart as &u64) + *(rhsStart as &u64);
-        } else {
-            unreachable("int add with sus bitsize");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_INT_SUB) {
-        // OPT: Specialized 8bit, 16bit, etc. variations
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "SubInt LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "SubInt RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let signed: bool = isSignedInteger(t1);
-        let s1: usize = rLhs.size;
-        let s2: usize = rRhs.size;
-        assert(s1 == s2, "SubInt expected LHS and RHS to be the same size");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: s1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        if (s1 == 1) {
-            if (signed) *(start as &i8) = *(lhsStart as &i8) - *(rhsStart as &i8);
-            else *(start as &u8) = *(lhsStart as &u8) - *(rhsStart as &u8);
-        } else if (s1 == 2) {
-            if (signed) *(start as &i16) = *(lhsStart as &i16) - *(rhsStart as &i16);
-            else *(start as &u16) = *(lhsStart as &u16) - *(rhsStart as &u16);
-        } else if (s1 == 4) {
-            if (signed) *(start as &i32) = *(lhsStart as &i32) - *(rhsStart as &i32);
-            else *(start as &u32) = *(lhsStart as &u32) - *(rhsStart as &u32);
-        } else if (s1 == 8) {
-            if (signed) *(start as &i64) = *(lhsStart as &i64) - *(rhsStart as &i64);
-            else *(start as &u64) = *(lhsStart as &u64) - *(rhsStart as &u64);
-        } else {
-            unreachable("int add with sus bitsize");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_INT_MUL) {
-        // OPT: Specialized 8bit, 16bit, etc. variations
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "MulInt LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "MulInt RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let signed: bool = isSignedInteger(t1);
-        let s1: usize = rLhs.size;
-        let s2: usize = rRhs.size;
-        assert(s1 == s2, "MulInt expected LHS and RHS to be the same size");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: s1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        if (s1 == 1) {
-            if (signed) *(start as &i8) = *(lhsStart as &i8) * *(rhsStart as &i8);
-            else *(start as &u8) = *(lhsStart as &u8) * *(rhsStart as &u8);
-        } else if (s1 == 2) {
-            if (signed) *(start as &i16) = *(lhsStart as &i16) * *(rhsStart as &i16);
-            else *(start as &u16) = *(lhsStart as &u16) * *(rhsStart as &u16);
-        } else if (s1 == 4) {
-            if (signed) *(start as &i32) = *(lhsStart as &i32) * *(rhsStart as &i32);
-            else *(start as &u32) = *(lhsStart as &u32) * *(rhsStart as &u32);
-        } else if (s1 == 8) {
-            if (signed) *(start as &i64) = *(lhsStart as &i64) * *(rhsStart as &i64);
-            else *(start as &u64) = *(lhsStart as &u64) * *(rhsStart as &u64);
-        } else {
-            unreachable("int mul with sus bitsize");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_INT_MOD) {
-        // OPT: Specialized 8bit, 16bit, etc. variations
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "ModInt LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "ModInt RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let signed: bool = isSignedInteger(t1);
-        let s1: usize = rLhs.size;
-        let s2: usize = rRhs.size;
-        assert(s1 == s2, "ModInt expected LHS and RHS to be the same size");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: s1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        if (s1 == 1) {
-            if (signed) *(start as &i8) = *(lhsStart as &i8) % *(rhsStart as &i8);
-            else *(start as &u8) = *(lhsStart as &u8) % *(rhsStart as &u8);
-        } else if (s1 == 2) {
-            if (signed) *(start as &i16) = *(lhsStart as &i16) % *(rhsStart as &i16);
-            else *(start as &u16) = *(lhsStart as &u16) % *(rhsStart as &u16);
-        } else if (s1 == 4) {
-            if (signed) *(start as &i32) = *(lhsStart as &i32) % *(rhsStart as &i32);
-            else *(start as &u32) = *(lhsStart as &u32) % *(rhsStart as &u32);
-        } else if (s1 == 8) {
-            if (signed) *(start as &i64) = *(lhsStart as &i64) % *(rhsStart as &i64);
-            else *(start as &u64) = *(lhsStart as &u64) % *(rhsStart as &u64);
-        } else {
-            unreachable("int mod with sus bitsize");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_FLOAT_DIV) {
-        // OPT: Specialized 8bit, 16bit, etc. variations
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "FloatDiv LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "FloatDiv RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let s1: usize = rLhs.size;
-        let s2: usize = rRhs.size;
-        assert(s1 == s2, "FloatDiv expected LHS and RHS to be the same size");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: s1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        if (s1 == 4) {
-            *(start as &f32) = *(lhsStart as &f32) / *(rhsStart as &f32);
-        } else if (s1 == 8) {
-            *(start as &f64) = *(lhsStart as &f64) / *(rhsStart as &f64);
-        } else {
-            unreachable("float div with sus bitsize");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_INT_CMP_EQ || instr.kind == INSTR_INT_CMP_NEQ) {
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "ICmpNeq/ICmpEq LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "ICmpNeq/ICmpEq RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let t2: &Type = getRegister(irFunc, instr.op1).typ;
-        let s1: usize = getSize(t1);
-        let s2: usize = getSize(t2);
-        assert(s1 == s2, "ICmpNeq/ICmpEq got differently sized operands");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        let eq: bool = false;
-        if (isInteger(t1) || isPointer(t1) || isChar(t1)) {
-            let signed: bool = isSignedInteger(t1);
-            if (s1 == 1) {
-                if (signed) eq = *(lhsStart as &i8) == *(rhsStart as &i8);
-                else eq = *(lhsStart as &u8) == *(rhsStart as &u8);
-            } else if (s1 == 2) {
-                if (signed) eq = *(lhsStart as &i16) == *(rhsStart as &i16);
-                else eq = *(lhsStart as &u16) == *(rhsStart as &u16);
-            } else if (s1 == 4) {
-                if (signed) eq = *(lhsStart as &i32) == *(rhsStart as &i32);
-                else eq = *(lhsStart as &u32) == *(rhsStart as &u32);
-            } else if (s1 == 8) {
-                if (signed) eq = *(lhsStart as &i64) == *(rhsStart as &i64);
-                else eq = *(lhsStart as &u64) == *(rhsStart as &u64);
-            } else {
-                unreachable("int cmp with sus bitsize");
-            }
-        } else {
-            unreachable("Interp ICmpEq/ICmpNeq on non-int");
-        }
-        let r: u8 = 0;
-        if (eq) r = 1;
-        if (instr.kind == INSTR_INT_CMP_NEQ) r = 1 - r;
-        *start = r;
-        return dst;
-    } else if (instr.kind == INSTR_INT_CMP_GT || instr.kind == INSTR_INT_CMP_LTE) {
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "ICmpGt/ICmpLte LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "ICmpGt/ICmpLte RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let t2: &Type = getRegister(irFunc, instr.op1).typ;
-        let s1: usize = getSize(t1);
-        let s2: usize = getSize(t2);
-        assert(s1 == s2, "ICmpGt/ICmpLte got differently sized operands");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        let gt: bool = false;
-        if (isInteger(t1)) {
-            let signed: bool = isSignedInteger(t1);
-            if (s1 == 1) {
-                if (signed) gt = *(lhsStart as &i8) > *(rhsStart as &i8);
-                else gt = *(lhsStart as &u8) > *(rhsStart as &u8);
-            } else if (s1 == 2) {
-                if (signed) gt = *(lhsStart as &i16) > *(rhsStart as &i16);
-                else gt = *(lhsStart as &u16) > *(rhsStart as &u16);
-            } else if (s1 == 4) {
-                if (signed) gt = *(lhsStart as &i32) > *(rhsStart as &i32);
-                else gt = *(lhsStart as &u32) > *(rhsStart as &u32);
-            } else if (s1 == 8) {
-                if (signed) gt = *(lhsStart as &i64) > *(rhsStart as &i64);
-                else gt = *(lhsStart as &u64) > *(rhsStart as &u64);
-            } else {
-                unreachable("int cmpgt with sus bitsize");
-            }
-        } else {
-            unreachable("Interp ICmpGt/ICmpLte on non-int");
-        }
-        let r: u8 = 0;
-        if (gt) r = 1;
-        if (instr.kind == INSTR_INT_CMP_LTE) r = 1 - r;
-        *start = r;
-        return dst;
-    } else if (instr.kind == INSTR_INT_CMP_LT || instr.kind == INSTR_INT_CMP_GTE) {
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "ICmpLt/ICmpGte LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "ICmpLt/ICmpGte RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let t2: &Type = getRegister(irFunc, instr.op1).typ;
-        let s1: usize = getSize(t1);
-        let s2: usize = getSize(t2);
-        assert(s1 == s2, "ICmpLt/ICmpGte got differently sized operands");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        let gt: bool = false;
-        if (isInteger(t1)) {
-            let signed: bool = isSignedInteger(t1);
-            if (s1 == 1) {
-                if (signed) gt = *(lhsStart as &i8) < *(rhsStart as &i8);
-                else gt = *(lhsStart as &u8) < *(rhsStart as &u8);
-            } else if (s1 == 2) {
-                if (signed) gt = *(lhsStart as &i16) < *(rhsStart as &i16);
-                else gt = *(lhsStart as &u16) < *(rhsStart as &u16);
-            } else if (s1 == 4) {
-                if (signed) gt = *(lhsStart as &i32) < *(rhsStart as &i32);
-                else gt = *(lhsStart as &u32) < *(rhsStart as &u32);
-            } else if (s1 == 8) {
-                if (signed) gt = *(lhsStart as &i64) < *(rhsStart as &i64);
-                else gt = *(lhsStart as &u64) < *(rhsStart as &u64);
-            } else {
-                unreachable("int cmpgt with sus bitsize");
-            }
-        } else {
-            unreachable("Interp ICmpGt/ICmpLte on non-int");
-        }
-        let r: u8 = 0;
-        if (gt) r = 1;
-        if (instr.kind == INSTR_INT_CMP_GTE) r = 1 - r;
-        *start = r;
-        return dst;
-    } else if (instr.kind == INSTR_FLOAT_CMP_EQ || instr.kind == INSTR_FLOAT_CMP_NEQ) {
-        let lhs: &RegValue = at(regs, instr.src.i);
-        let rhs: &RegValue = at(regs, instr.op1.i);
-        let rLhs: InterpReg =  asInterp(lhs, "FCmpNeq/FCmpEq LHS");
-        let rRhs: InterpReg =  asInterp(rhs, "FCmpNeq/FCmpEq RHS");
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let t2: &Type = getRegister(irFunc, instr.op1).typ;
-        let s1: usize = getSize(t1);
-        let s2: usize = getSize(t2);
-        assert(s1 == s2, "FCmpNeq/FCmpEq got differently sized operands");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 1,
-        };
-        let start: &u8 = getRegStackPointer(this, &dst);
-        let lhsStart: &u8 = getRegStackPointer(this, &rLhs);
-        let rhsStart: &u8 = getRegStackPointer(this, &rRhs);
-        let eq: bool = false;
-        if (isFloat(t1)) {
-            if (s1 == 4) {
-                eq = *(lhsStart as &f32) == *(rhsStart as &f32);
-            } else if (s1 == 8) {
-                eq = *(lhsStart as &f64) == *(rhsStart as &f64);
-            } else {
-                unreachable("float cmp with sus bitsize");
-            }
-        } else {
-            unreachable("Interp FCmpEq/FCmpNeq on non-float");
-        }
-        let r: u8 = 0;
-        if (eq) r = 1;
-        if (instr.kind == INSTR_FLOAT_CMP_NEQ) r = 1 - r;
-        *start = r;
-        return dst;
-    } else if (instr.kind == INSTR_LOGICAL_NOT) {
-        // dst: dst,
-        // src: src,
-        let src: &RegValue = at(regs, instr.src.i);
-        let rSrc: InterpReg = asInterp(src, "LNot SRC");
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let t1: &Type = getRegister(irFunc, instr.src).typ;
-        let s1: usize = getSize(t1);
-        assert(s1 == 1, "Idk");
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: s1,
-        };
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let srcStart: &u8 = getRegStackPointer(this, &rSrc);
-        let val: u8 = *srcStart;
-        assert(val == 0 || val == 1, "Logical Not got non-zero non-one");
-        *dstStart = 1 - val;
-        return dst;
-    } else if (instr.kind == INSTR_PTR_TO_INT) {
-        // noop in interpreter
-         return asInterp(at(regs, instr.src.i), "Interp PtrToInt");
-    } else if (instr.kind == INSTR_INT_TO_PTR) {
-        // noop in interpreter
-         return asInterp(at(regs, instr.src.i), "Interp IntToPtr");
-    } else if (instr.kind == INSTR_F32_TO_F64) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F32ToF64");
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 8,
-        };
-        let srcStart: &u8 = getRegStackPointer(this, &src);
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let v: f32 = *(srcStart as &f32);
-        *(dstStart as &f64) = v as f64;
-        return dst;
-    } else if (instr.kind == INSTR_INT_TO_F32) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp IntToF32");
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 4,
-        };
-        let srcStart: &u8 = getRegStackPointer(this, &src);
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let t: &Type = getRegister(irFunc, instr.src).typ;
-        let signed: bool = isSignedInteger(t);
-        let s: usize = getSize(t);
-        let v: f32 = 0;
-        if (s == 1) {
-            if (signed) v = *(srcStart as &i8) as f32;
-            else v = *(srcStart as &u8) as f32;
-        } else if (s == 2) {
-            if (signed) v = *(srcStart as &i16) as f32;
-            else v = *(srcStart as &u16) as f32;
-        } else if (s == 4) {
-            if (signed) v = *(srcStart as &i32) as f32;
-            else v = *(srcStart as &u32) as f32;
-        } else if (s == 8) {
-            if (signed) v = *(srcStart as &i64) as f32;
-            else v = *(srcStart as &u64) as f32;
-        } else {
-            unreachable("Interp unexpected size in IntToF32");
-        }
-        *(dstStart as &f32) = v;
-        return dst;
-    } else if (instr.kind == INSTR_F64_TO_F32) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F64ToF32");
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: 4,
-        };
-        let srcStart: &u8 = getRegStackPointer(this, &src);
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let v: f64 = *(srcStart as &f64);
-        *(dstStart as &f32) = v as f32;
-        return dst;
-    } else if (instr.kind == INSTR_F32_TO_INT) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F32ToInt");
-        let size: usize = getSize(dstReg.typ);
-        let signed: bool = isSignedInteger(dstReg.typ);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: size,
-        };
-        let srcStart: &u8 = getRegStackPointer(this, &src);
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let v: f32 = *(srcStart as &f32);
-        if (size == 1) {
-            if (signed) *(dstStart as &i8) = v as i8;
-            else *(dstStart as &u8) = v as u8;
-        } else if (size == 2) {
-            if (signed) *(dstStart as &i16) = v as i16;
-            else *(dstStart as &u16) = v as u16;
-        } else if (size == 4) {
-            if (signed) *(dstStart as &i32) = v as i32;
-            else *(dstStart as &u32) = v as u32;
-        } else if (size == 8) {
-            if (signed) *(dstStart as &i64) = v as i64;
-            else *(dstStart as &u64) = v as u64;
-        } else {
-            unreachable("Interp F32ToInt: Exhaustive handling of destinations");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_F64_TO_INT) {
-        let dstReg: &IRReg = getRegister(irFunc, instr.dst);
-        let src: InterpReg = asInterp(at(regs, instr.src.i), "Interp F64ToInt");
-        let size: usize = getSize(dstReg.typ);
-        let signed: bool = isSignedInteger(dstReg.typ);
-        let dst: InterpReg = InterpReg {
-            offset: dstReg.offset,
-            size: size,
-        };
-        let srcStart: &u8 = getRegStackPointer(this, &src);
-        let dstStart: &u8 = getRegStackPointer(this, &dst);
-        let v: f64 = *(srcStart as &f64);
-        if (size == 1) {
-            if (signed) *(dstStart as &i8) = v as i8;
-            else *(dstStart as &u8) = v as u8;
-        } else if (size == 2) {
-            if (signed) *(dstStart as &i16) = v as i16;
-            else *(dstStart as &u16) = v as u16;
-        } else if (size == 4) {
-            if (signed) *(dstStart as &i32) = v as i32;
-            else *(dstStart as &u32) = v as u32;
-        } else if (size == 8) {
-            if (signed) *(dstStart as &i64) = v as i64;
-            else *(dstStart as &u64) = v as u64;
-        } else {
-            unreachable("Interp F64ToInt: Exhaustive handling of destinations");
-        }
-        return dst;
-    } else if (instr.kind == INSTR_FETCH_COMPTIME_VALUE) {
-        // noop in interpreter
-        if (instr.op1.i == 1) {
-            // Global fetch
-            let fReg = getRegister(irFunc, instr.dst);
-            let ptr = getGlobalPointer(this, &asInterp(at(this.globalRegisters, instr.src.i), "Interp FetchComptimeValue"));
-            let size = getSize(fReg.typ);
-            let reg = InterpReg {
-                offset: fReg.offset,
-                size: size,
-            };
-            memcpy(getRegStackPointer(this, &reg), ptr, size);
-            return reg;
-        } else {
-            // Local fetch
-             return asInterp(at(regs, instr.src.i), "Interp FetchComptimeValue");
-        }
-    } else if (instr.kind == INSTR_GET_FIELD_PTR) {
-        // dst: elem,
-        // src: aggr,
-        // op1: RegIndex { i: index },
-        let fReg: &IRReg = getRegister(irFunc, instr.dst);
-        let fAggr: InterpReg = asInterp(at(regs, instr.src.i), "IRInterp: GetFieldPtr");
-        let t: &Type = getRegister(irFunc, instr.src).typ;
-        assert(isStructPointer(t), "IRInterp: GetFieldPtr got non-struct pointer");
-        let u: &Type = getUnderlyingType(t, false);
-        assert(isStruct(u));
-        let decl: &ParsedStructDecl = at(&structDecls, u.typeIndex);
-        let offset: usize = 0;
-        let size: usize = 0;
-        getFieldOffsetAndSize(decl, instr.op1.i, &offset, &size);
-        let reg: InterpReg = InterpReg {
-            offset: fReg.offset,
-            size: 8,
-        };
-        let regStackLoc: &u8 = getRegStackPointer(this, &reg);
-        let ptr: &u8 = getRegStackPointer(this, &fAggr);
-        *(regStackLoc as &usize) = *(ptr as &usize) + offset;
-        return reg;
-    } else {
-        printf("INTERP %llu\n", instr.kind);
-        todo_with_msg("unknown instr");
-    }
+    return instrFns[instr.kind](this, irFunc, instr, regs, forcedComptime);
 }
 func evaluateBlock(this: &IRInterp, blockID: &IRBlockID, irFunc: &IRFunc, regs: &RegValueList, forcedComptime: bool) -> bool {
     trace("IRInterp.evaluateBlock");
@@ -890,40 +1067,19 @@ func evaluateBlock(this: &IRInterp, blockID: &IRBlockID, irFunc: &IRFunc, regs: 
     assert(block.instructions.length > 0, "Interp: Encountered empty block");
     for (let ip: usize = 0; ip < block.instructions.length; ip = ip + 1) {
         let instr: &IRInstr = at(&block.instructions, ip);
+        let result = evaluateSingle(this, irFunc, instr, regs, forcedComptime);
         if (ip == block.instructions.length - 1) {
-            if (PRINT_DEBUG) dump(instr);
             assert(isTerminator(instr), "Interp: Unexpected non-terminator at the end of a block");
-            if (instr.kind == INSTR_BR) {
-                *blockID = IRBlockID { i: instr.dst.i };
-                return true;
-            } else if (instr.kind == INSTR_COND_BR) {
-                let cond: &RegValue = &*at(regs, instr.src.i);
-                let rCond: InterpReg =  asInterp(cond, "CondBr");
-                assert(rCond.size == 1, "comptime CondBr expected single byte Cond");
-                let condLoc: &u8 = getRegStackPointer(this, &rCond);
-                let v: u8 = *condLoc;
-                assert(v == 0 || v == 1, "condition is not 0 or 1");
-                if (v == 1) {
-                    *blockID = IRBlockID { i: instr.dst.i };
-                } else {
-                    *blockID = IRBlockID { i: instr.op1.i };
-                }
-                return true;
-            } else if (instr.kind == INSTR_RETURN_EXPR) {
-                let expr: &RegValue = &*at(regs, instr.src.i);
-                let rExpr: InterpReg =  asInterp(expr, "ReturnExpr");
-                pushArgument(this, getRegStackPointer(this, &rExpr), rExpr.size);
-                return false;
-            } else if (instr.kind == INSTR_RETURN_VOID) {
-                return false;
-            } else {
-                unreachable("Interp: Exhaustive handling of Terminators");
+            let ret = result.size == 1;
+            if (ret) {
+                *blockID = IRBlockID { i: result.offset };
             }
+            return ret;
         } else {
             assert(!isTerminator(instr), "Interp: Unexpected terminator in the middle of a block");
             *(at(regs, instr.dst.i)) = RegValue {
                 isLLVM: false,
-                regValue: evaluateSingle(this, irFunc, instr, regs, true),
+                regValue: result,
                 llvmValue: blank,
             };
         }

--- a/src/backend/irgen.bufo
+++ b/src/backend/irgen.bufo
@@ -2025,7 +2025,17 @@ func prepareParameter(this: &IRGen, function: &IRFunc, index: usize, span: Span,
             addEntry(last(&function.scopes), name, allocReg, false);
         }
     } else if (getSize(typ) > 8) {
-        unreachable("IRGen.prepareParameter: The only types that are bigger than 8 bytes are structs");
+        let t = newType(TYPE_KIND_POINTER, TYPE_U8);
+        let value: RegIndex = allocateRegister(function, t);
+        let allocType: &Type = at(&types, intoPointer(typ));
+        let allocReg: RegIndex = allocateRegister(function, allocType);
+        buildGetParam(function, span, value, index, getSize(t));
+        let instance: RegIndex = allocateRegister(function, typ);
+        buildLoad(function, span, instance, value);
+
+        buildAlloca(function, span, allocReg, getSize(typ));
+        buildStore(function, span, allocReg, instance);
+        addEntry(last(&function.scopes), name, allocReg, false);
     } else {
         let allocType: &Type = at(&types, intoPointer(typ));
         let allocReg: RegIndex = allocateRegister(function, allocType);

--- a/src/backend/irgen.bufo
+++ b/src/backend/irgen.bufo
@@ -29,6 +29,7 @@ func equals(this: &IRReg, other: &IRReg) -> bool {
     unreachable("IRReg.equals is not implemented yet");
 }
 
+// NOTE: When you update this list, you must also update the function pointers in the interpreter
 comptime INSTR_INVALID: usize = 0;
 comptime INSTR_ALLOCA: usize = 1;
 comptime INSTR_GET_PARAM: usize = 2;

--- a/src/backend/irgen.bufo
+++ b/src/backend/irgen.bufo
@@ -124,6 +124,11 @@ func isTerminator(this: &IRInstr) -> bool {
 }
 func dump(this: &IRInstr) {
     if (this.isComptime) printf("\x1b[92m");
+    if (PRINT_DEBUG) {
+        let s = toString(&this.span);
+        printf("%s ", s.buffer);
+        drop(&s);
+    }
     if (this.kind == INSTR_ALLOCA) printf("r%llu = Alloca %llu", this.dst.i, this.src.i);
     else if (this.kind == INSTR_GET_PARAM) printf("r%llu = GetParam %llu (%llu bytes)", this.dst.i, this.src.i, this.op1.i);
     else if (this.kind == INSTR_STORE) printf("Store r%llu, r%llu", this.dst.i, this.src.i);
@@ -131,9 +136,10 @@ func dump(this: &IRInstr) {
     else if (this.kind == INSTR_FETCH_GLOBAL_VALUE) printf("r%llu = FetchGlobalValue r%llu", this.dst.i, this.src.i);
     else if (this.kind == INSTR_FETCH_COMPTIME_VALUE) printf("r%llu = FetchComptimeValue r%llu, global=%llu", this.dst.i, this.src.i, this.op1.i);
     else if (this.kind == INSTR_LOAD) printf("r%llu = Load r%llu", this.dst.i, this.src.i);
+    else if (this.kind == INSTR_LOAD_FUNCTION_PTR) printf("r%llu = LoadFunctionPtr %llu", this.dst.i, this.src.i);
     else if (this.kind == INSTR_MOVE) printf("r%llu = Move r%llu", this.dst.i, this.src.i);
     else if (this.kind == INSTR_CALL) {
-        printf("r%llu = Call %llu", this.dst.i, this.src.i);
+        printf("r%llu = Call r%llu", this.dst.i, this.src.i);
         for (let i: usize = 0; i < this.args.length; i = i + 1) {
             printf(", r%llu", at(&this.args, i).i);
         }
@@ -1404,11 +1410,11 @@ func generateBytecodeExprMemberAccess(this: &IRGen, function: &IRFunc, expr: &Pa
     }
 }
 
-func prepareReturnValue(this: &IRGen, span: Span, function: &IRFunc, funcID: usize, args: RegIndexList, retType: &Type, retPtr: RegIndex, needsPtr: bool) -> RegIndex {
+func prepareReturnValue(this: &IRGen, span: Span, function: &IRFunc, base: RegIndex, args: RegIndexList, retType: &Type, retPtr: RegIndex, needsPtr: bool) -> RegIndex {
     let retVal: RegIndex = blank;
     if (getSize(retType) > 8) {
         let reg: RegIndex = allocateRegister(function, retType);
-        buildCall(function, span, retPtr, RegIndex { i: funcID }, args);
+        buildCall(function, span, retPtr, base, args);
         if (needsPtr) {
             retVal = retPtr;
         } else {
@@ -1418,7 +1424,7 @@ func prepareReturnValue(this: &IRGen, span: Span, function: &IRFunc, funcID: usi
     } else {
         if (isStruct(retType)) {
             let reg: RegIndex = getRegisterForSize(this, function, getSize(retType));
-            buildCall(function, span, reg, RegIndex { i: funcID }, args);
+            buildCall(function, span, reg, base, args);
             let v: RegIndex = allocateRegister(function, retType);
             let t: &Type = getRegister(function, v).typ;
             let r: RegIndex = allocateRegister(function, at(&types, intoPointer(t)));
@@ -1434,7 +1440,7 @@ func prepareReturnValue(this: &IRGen, span: Span, function: &IRFunc, funcID: usi
             }
         } else {
             let reg: RegIndex = allocateRegister(function, retType);
-            buildCall(function, span, reg, RegIndex { i: funcID }, args);
+            buildCall(function, span, reg, base, args);
             if (needsPtr) {
                 let tempAlloc: RegIndex = allocateRegister(function, at(&types, intoPointer(retType)));
                 buildAlloca(function, span, tempAlloc, getSize(retType));
@@ -1445,9 +1451,10 @@ func prepareReturnValue(this: &IRGen, span: Span, function: &IRFunc, funcID: usi
             }
         }
     }
-    let f = at(&this.functions, funcID);
-    assert(f != null);
-    if (hasAttribute(f, ATTR_NORETURN)) {
+    let ft: &Type = getRegister(function, base).typ;
+    if (isPointer(ft)) ft = getUnderlyingType(ft, true);
+    assert(isFunction(ft), "IRGen: Base is not a function");
+    if (isNoreturn(ft)) {
         buildUnreachable(function, span);
     }
     return retVal;
@@ -1503,7 +1510,13 @@ func generateBytecodeExprIndexedAccess(this: &IRGen, function: &IRFunc, expr: &P
         push(&args, err);
         push(&args, rhs);
         let reg: RegIndex = allocateRegister(function, newType(TYPE_KIND_PRIMITIVE, TYPE_NONE));
-        buildCall(function, expr.span, reg, RegIndex { i: funcID }, args);
+        {
+            let ft = newType(TYPE_KIND_FUNCTION, TYPE_NONE);
+            ft.arraySize = ft.arraySize | FUNC_TYPE_VARIADIC;
+            let dst = allocateRegister(function, ft);
+            buildLoadFunctionPtr(function, expr.span, dst, funcID);
+            buildCall(function, expr.span, reg, dst, args);
+        }
         buildUnreachable(function, expr.span);
         setCurrentBlock(function, normal);
     }
@@ -1585,11 +1598,7 @@ func generateBytecodeExprIdentifier(this: &IRGen, function: &IRFunc, expr: &Pars
         let funcID: usize = getFunctionByName(this, &name);
         let dst = allocateRegister(function, t);
         buildLoadFunctionPtr(function, expr.span, dst, funcID);
-        if (needsPtr) {
-            todo_with_msg("func ident needsPtr?");
-        } else {
-            return dst;
-        }
+        return dst;
     }
 }
 
@@ -2076,9 +2085,9 @@ func prepareArgument(this: &IRGen, function: &IRFunc, span: Span, value: RegInde
 func generateBytecodeExprCall(this: &IRGen, function: &IRFunc, expr: &ParsedExpr, needsPtr: bool) -> RegIndex {
     trace("IRGen.generateBytecodeExprCall");
     assert(isCall(expr));
+    let base = generateBytecodeExpr(this, function, at(&exprs, expr.lhs), false);
     let typ: &Type = at(&types, getType(&expr.typeState));
     let args: RegIndexList = blank;
-    let reg: RegIndex = allocateRegister(function, typ);
     let retPtr: RegIndex = blank;
     if (getSize(typ) > 8) {
         retPtr = allocateRegister(function, at(&types, intoPointer(typ)));
@@ -2091,10 +2100,7 @@ func generateBytecodeExprCall(this: &IRGen, function: &IRFunc, expr: &ParsedExpr
         let result: RegIndex = generateBytecodeExpr(this, function, arg, false);
         push(&args, prepareArgument(this, function, arg.span, result, argType));
     }
-    let name: String = getMangledName(at(&funcDecls, expr.lhs));
-    let funcID: usize = getFunctionByName(this, &name);
-    drop(&name);
-    return prepareReturnValue(this, expr.span, function, funcID, args, typ, retPtr, needsPtr);
+    return prepareReturnValue(this, expr.span, function, base, args, typ, retPtr, needsPtr);
 }
 
 func newIRGenerator() -> IRGen {

--- a/src/backend/irgen.bufo
+++ b/src/backend/irgen.bufo
@@ -1334,6 +1334,12 @@ func generateBytecodeExprAs(this: &IRGen, function: &IRFunc, expr: &ParsedExpr) 
         buildPtrToInt(function, expr.span, dst, result);
     } else if (isPointer(current) && isPointer(target)) {
         buildMove(function, expr.span, dst, result);
+    } else if (isFunction(current) && isFunction(target)) {
+        buildMove(function, expr.span, dst, result);
+    } else if (isAny(current) && isFunction(target)) {
+        buildMove(function, expr.span, dst, result);
+    } else if (isFunction(current) && isAny(target)) {
+        buildMove(function, expr.span, dst, result);
     } else if ((isChar(current) || isInteger(current)) && (isChar(target) || isInteger(target))) {
         if (getSize(current) < getSize(target)) {
             if (isSignedInteger(current)) {
@@ -1850,6 +1856,15 @@ func generateBytecodeExprLiteral(this: &IRGen, function: &IRFunc, expr: &ParsedE
                 let elem: &ParsedExpr = at(&exprs, getElementAtIndex(&expr.arrayContext, i));
                 let result: RegIndex = generateBytecodeExpr(this, function, elem, false);
                 buildInsertValue(function, expr.span, reg, i, result);
+            }
+            if (needsPtr) {
+                let subType: &Type = at(&types, intoPointer(t));
+                let ptr: RegIndex = allocateRegister(function, subType);
+                buildAlloca(function, expr.span, ptr, getSize(t));
+                buildStore(function, expr.span, ptr, reg);
+                return ptr;
+            } else {
+                return reg;
             }
         } else {
             let elem: &ParsedExpr = at(&exprs, getElementAtIndex(&expr.arrayContext, 0));

--- a/src/backend/irgen.bufo
+++ b/src/backend/irgen.bufo
@@ -36,6 +36,7 @@ comptime INSTR_STORE: usize = 3;
 comptime INSTR_FETCH_GLOBAL_PTR: usize = 4;
 comptime INSTR_FETCH_GLOBAL_VALUE: usize = 5;
 comptime INSTR_FETCH_COMPTIME_VALUE: usize = 6;
+comptime INSTR_LOAD_FUNCTION_PTR: usize = 7;
 comptime INSTR_LOAD: usize = 8;
 comptime INSTR_MOVE: usize = 9;
 comptime INSTR_CALL: usize = 10;
@@ -447,6 +448,17 @@ func buildFetchLocalComptimeValue(this: &IRFunc, span: Span, dst: RegIndex, glob
         dst: dst,
         src: globalIndex,
         op1: RegIndex { i: 0 },
+        args: blank,
+    });
+}
+func buildLoadFunctionPtr(this: &IRFunc, span: Span, dst: RegIndex, funcID: usize) {
+    pushInstruction(this, IRInstr {
+        kind: INSTR_LOAD_FUNCTION_PTR,
+        span: span,
+        isComptime: this.comptimeLevel > 0,
+        dst: dst,
+        src: RegIndex { i: funcID },
+        op1: blank,
         args: blank,
     });
 }
@@ -911,7 +923,7 @@ func getIdentifierByName(this: &IRGen, function: &IRFunc, name: SubStr, isGlobal
         *isGlobal = true;
         return entry;
     }
-    unreachable("Could not find identifier anywhere.");
+    return null;
 }
 func getFunctionByName(this: &IRGen, name: &String) -> usize {
     return indexOf(&this.functions, name);
@@ -1518,53 +1530,66 @@ func generateBytecodeExprIdentifier(this: &IRGen, function: &IRFunc, expr: &Pars
     assert(isIdentifier(expr));
     let isGlobal: bool = false;
     let entry: &IRScopeEntry = getIdentifierByName(this, function, expr.origToken.content, &isGlobal);
-    assert(entry != null, "Could not find identifier in generateBytecodeExprIdentifier");
-    let varType: &Type = at(&types, getType(&expr.typeState));
-    if (function.comptimeLevel > 0 && !entry.isComptime) {
-        unreachable("Crossing the boundary: comptime IR needs runtime value - The Checker should've caught this");
-    }
-    if (needsPtr) {
-        if (isGlobal) {
-            let ptrType: &Type = at(&types, intoPointer(varType));
-            let global: RegIndex = allocateRegister(function, ptrType);
-            if (entry.isComptime) {
-                let val: RegIndex = allocateRegister(function, varType);
-                buildAlloca(function, expr.span, global, getSize(varType));
-                buildFetchGlobalComptimeValue(function, expr.span, val, entry.ptr);
-                buildStore(function, expr.span, global, val);
-            } else {
-                buildFetchGlobalPointer(function, expr.span, global, entry.ptr);
-            }
-            return global;
-        } else {
-            if (entry.isComptime) {
+    if (entry != null) {
+        let varType: &Type = at(&types, getType(&expr.typeState));
+        if (function.comptimeLevel > 0 && !entry.isComptime) {
+            unreachable("Crossing the boundary: comptime IR needs runtime value - The Checker should've caught this");
+        }
+        if (needsPtr) {
+            if (isGlobal) {
                 let ptrType: &Type = at(&types, intoPointer(varType));
                 let global: RegIndex = allocateRegister(function, ptrType);
-                let val: RegIndex = allocateRegister(function, varType);
-                buildAlloca(function, expr.span, global, getSize(varType));
-                buildFetchLocalComptimeValue(function, expr.span, val, entry.ptr);
-                buildStore(function, expr.span, global, val);
+                if (entry.isComptime) {
+                    let val: RegIndex = allocateRegister(function, varType);
+                    buildAlloca(function, expr.span, global, getSize(varType));
+                    buildFetchGlobalComptimeValue(function, expr.span, val, entry.ptr);
+                    buildStore(function, expr.span, global, val);
+                } else {
+                    buildFetchGlobalPointer(function, expr.span, global, entry.ptr);
+                }
                 return global;
             } else {
-                return entry.ptr;
-            }
-        }
-    } else {
-        let val: RegIndex = allocateRegister(function, varType);
-        if (isGlobal) {
-            if (entry.isComptime) {
-                buildFetchGlobalComptimeValue(function, expr.span, val, entry.ptr);
-            } else {
-                buildFetchGlobalRuntimeValue(function, expr.span, val, entry.ptr);
+                if (entry.isComptime) {
+                    let ptrType: &Type = at(&types, intoPointer(varType));
+                    let global: RegIndex = allocateRegister(function, ptrType);
+                    let val: RegIndex = allocateRegister(function, varType);
+                    buildAlloca(function, expr.span, global, getSize(varType));
+                    buildFetchLocalComptimeValue(function, expr.span, val, entry.ptr);
+                    buildStore(function, expr.span, global, val);
+                    return global;
+                } else {
+                    return entry.ptr;
+                }
             }
         } else {
-            if (entry.isComptime) {
-                buildFetchLocalComptimeValue(function, expr.span, val, entry.ptr);
+            let val: RegIndex = allocateRegister(function, varType);
+            if (isGlobal) {
+                if (entry.isComptime) {
+                    buildFetchGlobalComptimeValue(function, expr.span, val, entry.ptr);
+                } else {
+                    buildFetchGlobalRuntimeValue(function, expr.span, val, entry.ptr);
+                }
             } else {
-                buildLoad(function, expr.span, val, entry.ptr);
+                if (entry.isComptime) {
+                    buildFetchLocalComptimeValue(function, expr.span, val, entry.ptr);
+                } else {
+                    buildLoad(function, expr.span, val, entry.ptr);
+                }
             }
+            return val;
         }
-        return val;
+    } else {
+        let t = at(&types, getType(&expr.typeState));
+        assert(isFunction(t), "Expected function in generateBytecodeExprIdentifier");
+        let name: String = getMangledName(at(&funcDecls, expr.lhs));
+        let funcID: usize = getFunctionByName(this, &name);
+        let dst = allocateRegister(function, t);
+        buildLoadFunctionPtr(function, expr.span, dst, funcID);
+        if (needsPtr) {
+            todo_with_msg("func ident needsPtr?");
+        } else {
+            return dst;
+        }
     }
 }
 

--- a/src/bufo.bufo
+++ b/src/bufo.bufo
@@ -16,6 +16,7 @@ import "./backend/interp.bufo";
 import "./backend/codegen_llvm.bufo";
 
 let flagParser = FlagParser {};
+// FIXME: Flag like -w that prints extra warnings instead of globbering -v
 struct Flags {
     file: &String;
     out: &String;

--- a/src/frontend/nodes.bufo
+++ b/src/frontend/nodes.bufo
@@ -281,6 +281,13 @@ struct ParsedFuncDecl {
     typeState: TCState;
 }
 
+func hasAttribute(this: &ParsedFuncDecl, attr: usize) -> bool {
+    trace("ParsedFuncDecl.hasAttribute");
+    for (let i: usize = 0; i < this.attrs.length; i = i + 1) {
+        if (at(&this.attrs, i).kind == attr) return true;
+    }
+    return false;
+}
 func getID(this: &ParsedFuncDecl) -> usize {
     trace("ParsedFuncDecl.getID");
     return indexOf(&funcDecls, this);
@@ -660,13 +667,14 @@ comptime BIN_CMP_EQ: usize = 11;
 comptime BIN_ASSIGN: usize = 12;
 comptime BIN_AS: usize = 13;
 comptime BIN_INDEXED_ACCESS: usize = 14;
-comptime BIN_MOD: usize = 15;
+comptime BIN_CALL: usize = 15;
+comptime BIN_MOD: usize = 16;
 // FIXME: Those names are pretty easy to mix up
-comptime BIN_LAND: usize = 16;
-comptime BIN_LOR: usize = 17;
-comptime BIN_BAND: usize = 18;
-comptime BIN_BOR: usize = 19;
-comptime BIN_BXOR: usize = 20;
+comptime BIN_LAND: usize = 17;
+comptime BIN_LOR: usize = 18;
+comptime BIN_BAND: usize = 19;
+comptime BIN_BOR: usize = 20;
+comptime BIN_BXOR: usize = 21;
 func binOpFromKind(kind: usize) -> usize {
     trace("binOpFromKind");
     if (kind == TOKEN_PLUS_SINGLE) return BIN_PLUS;
@@ -684,6 +692,7 @@ func binOpFromKind(kind: usize) -> usize {
     // FIXME: We can't know if this is actually KEYWORD_AS
     else if (kind == TOKEN_KEYWORD) return BIN_AS;
     else if (kind == TOKEN_SQUARE_OPEN) return BIN_INDEXED_ACCESS;
+    else if (kind == TOKEN_PAREN_OPEN) return BIN_CALL;
     else if (kind == TOKEN_PERCENT) return BIN_MOD;
     else if (kind == TOKEN_PIPE_SINGLE) return BIN_BOR;
     else if (kind == TOKEN_PIPE_DOUBLE) return BIN_LOR;

--- a/src/frontend/nodes.bufo
+++ b/src/frontend/nodes.bufo
@@ -450,7 +450,8 @@ comptime PARSED_TYPE_REF: usize = 17;
 comptime PARSED_TYPE_ARRAY: usize = 18;
 comptime PARSED_TYPE_F32: usize = 19;
 comptime PARSED_TYPE_F64: usize = 20;
-comptime PARSED_TYPE_BUILTIN: usize = 21;
+comptime PARSED_TYPE_FUNC: usize = 21;
+comptime PARSED_TYPE_BUILTIN: usize = 22;
 func BUILD_A_TYPE(s: &char) -> SubStr {
     return SubStr {
         start: s,
@@ -494,6 +495,7 @@ struct ParsedTypeNode {
     span: Span;
     kind: usize;
     underlyingID: usize;
+    fnParams: UsizeList;
     arraySize: usize;
     nameTkn: Token;
     typeState: TCState;

--- a/src/frontend/parser.bufo
+++ b/src/frontend/parser.bufo
@@ -679,24 +679,7 @@ func parsePrimaryExpr(this: &Parser) -> &ParsedExpr {
         return expr;
     } else if (tknKind == TOKEN_IDENT) {
         let ident: Token = expect(this, TOKEN_IDENT);
-        if (at(this, TOKEN_PAREN_OPEN)) {
-            expect(this, TOKEN_PAREN_OPEN);
-            let context: ArrayContext = blank;
-            while (!parsedEOF(this) && !at(this, TOKEN_PAREN_CLOSE)) {
-                let expr: &ParsedExpr = parseExpr(this);
-                addElement(&context, expr);
-                if (!eat(this, TOKEN_COMMA))
-                    break;
-            }
-            let end: Token = expect(this, TOKEN_PAREN_CLOSE);
-            let span: Span = newSpanBetween(&ident.span, &end.span);
-            let expr: &ParsedExpr = newParsedExpr(span, EXPR_CALL);
-            // REVIEW: This assumes that we will only ever have idents as call bases
-            //         However I'd like to treat functions as first class citizen soon
-            (*expr).origToken = ident;
-            (*expr).arrayContext = context;
-            return expr;
-        } else if (at(this, TOKEN_CURLY_OPEN)) {
+        if (at(this, TOKEN_CURLY_OPEN)) {
             expect(this, TOKEN_CURLY_OPEN);
             let context: StructInitContext = blank;
             while (!parsedEOF(this) && !at(this, TOKEN_CURLY_CLOSE)) {
@@ -815,6 +798,21 @@ func parseSecondaryExpr(this: &Parser, lhs: &ParsedExpr, precedence: usize, asso
     if (op == BIN_INDEXED_ACCESS) {
         rhs = __parseExpr(this, 0, associativity);
         expect(this, TOKEN_SQUARE_CLOSE);
+    } else if (op == BIN_CALL) {
+        let context: ArrayContext = blank;
+        while (!parsedEOF(this) && !at(this, TOKEN_PAREN_CLOSE)) {
+            let expr: &ParsedExpr = parseExpr(this);
+            addElement(&context, expr);
+            if (!eat(this, TOKEN_COMMA))
+                break;
+        }
+        let end: Token = expect(this, TOKEN_PAREN_CLOSE);
+        let span: Span = newSpanBetween(&lhs.span, &end.span);
+        let call: &ParsedExpr = newParsedExpr(span, EXPR_CALL);
+        (*call).arrayContext = context;
+        (*call).op = op;
+        (*call).lhs = getID(lhs);
+        return call;
     } else {
         rhs = __parseExpr(this, precedence, associativity);
     }
@@ -894,6 +892,7 @@ func matchesBinaryExpr(this: &Parser) -> bool {
         || tknKind == TOKEN_CARET
         // REVIEW: Maybe make DOT an identifier expression instead?
         || tknKind == TOKEN_DOT
+        || tknKind == TOKEN_PAREN_OPEN
         || tknKind == TOKEN_SQUARE_OPEN
         || tknKind == TOKEN_PERCENT;
 }
@@ -913,6 +912,7 @@ func getBinaryPrecedence(this: &Parser, tkn: &Token) -> usize {
     trace("Parser.getBinaryPrecedence");
     let tknKind: usize = tkn.kind;
     if (tknKind == TOKEN_DOT) return 17;
+    else if (tknKind == TOKEN_PAREN_OPEN) return 16;
     else if (tknKind == TOKEN_SQUARE_OPEN) return 16;
     else if (tknKind == TOKEN_KEYWORD) {
         assert(equals(&tkn.content, &KEYWORD_AS), "unsupported keyword in getBinaryPrecedence");

--- a/src/frontend/parser.bufo
+++ b/src/frontend/parser.bufo
@@ -298,7 +298,7 @@ func parseStructDecl(this: &Parser) -> &ParsedStructDecl {
     while (!parsedEOF(this) && !at(this, TOKEN_CURLY_CLOSE)) {
         let tkn = expect(this, TOKEN_IDENT);
         expect(this, TOKEN_COLON);
-        let typ: &ParsedTypeNode = parseTypeDecl(this);
+        let typ: &ParsedTypeNode = parseTypeNode(this);
         addField(&structContext, tkn, typ);
         expect(this, TOKEN_SEMI_COLON);
     }
@@ -331,7 +331,7 @@ func parseFuncDecl(this: &Parser, isExtern: bool) -> &ParsedFuncDecl {
 func parseReturnType(this: &Parser) -> &ParsedTypeNode {
     trace("Parser.parseReturnType");
     if (eat(this, TOKEN_ARROW)) {
-        return parseTypeDecl(this);
+        return parseTypeNode(this);
     } else {
         return newBuiltinTypeDecl(peek(&this.lexer).span, PARSED_TYPE_NONE);
     }
@@ -359,7 +359,7 @@ func parseParameters(this: &Parser, parentName: Token) -> ParamContext {
         if (isThis) {
             let dis: Token = expect(this, TOKEN_IDENT);
             if (eat(this, TOKEN_COLON)) {
-                let t = parseTypeDecl(this);
+                let t = parseTypeNode(this);
                 addParameter(&context, maybeThis, t);
             } else {
                 let thisType: &ParsedTypeNode = newParsedTypeNode(maybeThis.span, PARSED_TYPE_IDENT);
@@ -375,7 +375,7 @@ func parseParameters(this: &Parser, parentName: Token) -> ParamContext {
         } else {
             let name: Token = expect(this, TOKEN_IDENT);
             expect(this, TOKEN_COLON);
-            let typ: &ParsedTypeNode = parseTypeDecl(this);
+            let typ: &ParsedTypeNode = parseTypeNode(this);
             addParameter(&context, name, typ);
         }
         if (!eat(this, TOKEN_COMMA))
@@ -567,7 +567,7 @@ func parseVarDeclStmt(this: &Parser, kw: Token, isGlobal: bool) -> &ParsedStmt {
     let data: VarDeclContext = blank;
     data.name = nameTkn;
     if (eat(this, TOKEN_COLON)) {
-        data.typeID = getID(parseTypeDecl(this));
+        data.typeID = getID(parseTypeNode(this));
     }
     expect(this, TOKEN_EQUAL_SINGLE);
     data.exprID = getID(parseExpr(this));
@@ -584,10 +584,32 @@ func parseVarDeclStmt(this: &Parser, kw: Token, isGlobal: bool) -> &ParsedStmt {
     return decl;
 }
 
-func parseTypeDecl(this: &Parser) -> &ParsedTypeNode {
-    trace("Parser.parseTypeDecl");
+func parseTypeNode(this: &Parser) -> &ParsedTypeNode {
+    trace("Parser.parseTypeNode");
     let loc: Token = peek(&this.lexer);
-    if (eat(this, TOKEN_AMPERSAND_DOUBLE)) {
+    if (at(this, TOKEN_KEYWORD)) {
+        let kw = peek(&this.lexer);
+        if (!equals(&kw.content, &KEYWORD_FUNC)) {
+            expect(this, TOKEN_IDENT);
+        }
+        next(&this.lexer);
+        expect(this, TOKEN_PAREN_OPEN);
+        let params: UsizeList = blank;
+        while (!at(this, TOKEN_PAREN_CLOSE)) {
+            let pt = parseTypeNode(this);
+            if (!at(this, TOKEN_PAREN_CLOSE)) {
+                expect(this, TOKEN_COMMA);
+            }
+            push(&params, getID(pt));
+        }
+        expect(this, TOKEN_PAREN_CLOSE);
+        let retType = parseReturnType(this);
+        let span = newSpanBetween(&kw.span, &retType.span);
+        let funcNode = newParsedTypeNode(span, PARSED_TYPE_FUNC);
+        funcNode.underlyingID = getID(retType);
+        funcNode.fnParams = params;
+        return funcNode;
+    } else if (eat(this, TOKEN_AMPERSAND_DOUBLE)) {
         let kw: Token = peek(&this.lexer);
         if (equals(&kw.content, &KEYWORD_MUT)) {
             next(&this.lexer);
@@ -596,7 +618,7 @@ func parseTypeDecl(this: &Parser) -> &ParsedTypeNode {
             drop(&loc);
             exit(1);
         }
-        let typ: &ParsedTypeNode = parseTypeDecl(this);
+        let typ: &ParsedTypeNode = parseTypeNode(this);
         let span: Span = newSpanBetween(&loc.span, &typ.span);
         let ptr1: &ParsedTypeNode = newParsedTypeNode(span, PARSED_TYPE_REF);
         (*ptr1).underlyingID = getID(typ);
@@ -612,13 +634,13 @@ func parseTypeDecl(this: &Parser) -> &ParsedTypeNode {
             drop(&loc);
             exit(1);
         }
-        let typ: &ParsedTypeNode = parseTypeDecl(this);
+        let typ: &ParsedTypeNode = parseTypeNode(this);
         let span: Span = newSpanBetween(&loc.span, &typ.span);
         let ptr: &ParsedTypeNode = newParsedTypeNode(span, PARSED_TYPE_REF);
         (*ptr).underlyingID = getID(typ);
         return ptr;
     } else if (eat(this, TOKEN_SQUARE_OPEN)) {
-        let typ: &ParsedTypeNode = parseTypeDecl(this);
+        let typ: &ParsedTypeNode = parseTypeNode(this);
         expect(this, TOKEN_SEMI_COLON);
         let size: Token = expect(this, TOKEN_INT_LITERAL);
         let _size: String = toString(&size.content);
@@ -752,7 +774,7 @@ func parsePrimaryExpr(this: &Parser) -> &ParsedExpr {
             (*expr).origToken = kw;
             return expr;
         } else if (equals(&kw.content, &KEYWORD_SIZEOF)) {
-            let typ: &ParsedTypeNode = parseTypeDecl(this);
+            let typ: &ParsedTypeNode = parseTypeNode(this);
             let span: Span = newSpanBetween(&kw.span, &typ.span);
             let expr: &ParsedExpr = newParsedExpr(span, EXPR_SIZEOF);
             (*expr).lhs = getID(typ);
@@ -786,7 +808,7 @@ func parseSecondaryExpr(this: &Parser, lhs: &ParsedExpr, precedence: usize, asso
     let opTkn: Token = next(&this.lexer);
     let op: usize = binOpFromKind(opTkn.kind);
     if (op == BIN_AS) {
-        let typ: &ParsedTypeNode = parseTypeDecl(this);
+        let typ: &ParsedTypeNode = parseTypeNode(this);
         let span: Span = newSpanBetween(&lhs.span, &typ.span);
         let asop: &ParsedExpr = newParsedExpr(span, EXPR_AS);
         (*asop).op = op;

--- a/src/middleend/checker.bufo
+++ b/src/middleend/checker.bufo
@@ -13,33 +13,32 @@ import "./types.bufo";
 import "./lookup.bufo";
 
 comptime ERROR_INVALID: usize = 0;
-comptime ERROR_LOOKUP_NOT_READY: usize = 1;
-comptime ERROR_NO_SUCH_IDENTIFIER: usize = 2;
-comptime ERROR_NO_SUCH_FUNCTION: usize = 3;
-comptime ERROR_NO_SUCH_METHOD: usize = 4;
-comptime ERROR_USE_BEFORE_DECLARATION: usize = 5;
-comptime ERROR_FIELD_COUNT_MISMATCH: usize = 6;
-comptime ERROR_INDEXED_TYPE_MISMATCH: usize = 7;
-comptime ERROR_UNEXPECTED_LITERAL: usize = 8;
-comptime ERROR_ARRAY_SIZE_MISMATCH: usize = 9;
-comptime ERROR_TYPE_MISMATCH: usize = 10;
-comptime ERROR_INVALID_POINTER_ARITHMETIC: usize = 11;
-comptime ERROR_DUPLICATE_PARAMETER: usize = 12;
-comptime ERROR_DUPLICATE_FIELD: usize = 13;
-comptime ERROR_UNKNOWN_FIELD: usize = 14;
-comptime ERROR_DUPLICATE_FUNCTION: usize = 15;
-comptime ERROR_NO_CALL_CANDIDATE: usize = 16;
-comptime ERROR_VARIABLE_REDECLARATION: usize = 17;
-comptime ERROR_RECURSIVE_TYPE: usize = 18;
-comptime ERROR_DUPLICATE_METHOD: usize = 19;
-comptime ERROR_BLANK_FOR_NULL: usize = 20;
-comptime ERROR_NON_PRIMITIVE_CAST: usize = 21;
-comptime ERROR_INDEXED_ACCESS_ON_NON_ARRAY: usize = 22;
-comptime ERROR_RUNTIME_VALUE_IN_COMPTIME_CONTEXT: usize = 23;
-comptime ERROR_ANY_DEREF: usize = 24;
-comptime ERROR_MEMBER_ACCESS_NON_STRUCT: usize = 25;
-comptime ERROR_MEMBER_ACCESS_TOO_MANY_OPTIONS: usize = 26;
-comptime ERROR_FUNCTION_CALL_TOO_MANY_OPTIONS: usize = 27;
+comptime ERROR_NO_SUCH_IDENTIFIER: usize = 1;
+comptime ERROR_NO_SUCH_FUNCTION: usize = 2;
+comptime ERROR_NO_SUCH_METHOD: usize = 3;
+comptime ERROR_USE_BEFORE_DECLARATION: usize = 4;
+comptime ERROR_FIELD_COUNT_MISMATCH: usize = 5;
+comptime ERROR_INDEXED_TYPE_MISMATCH: usize = 6;
+comptime ERROR_UNEXPECTED_LITERAL: usize = 7;
+comptime ERROR_ARRAY_SIZE_MISMATCH: usize = 8;
+comptime ERROR_TYPE_MISMATCH: usize = 9;
+comptime ERROR_INVALID_POINTER_ARITHMETIC: usize = 10;
+comptime ERROR_DUPLICATE_PARAMETER: usize = 11;
+comptime ERROR_DUPLICATE_FIELD: usize = 12;
+comptime ERROR_UNKNOWN_FIELD: usize = 13;
+comptime ERROR_DUPLICATE_FUNCTION: usize = 14;
+comptime ERROR_NO_CALL_CANDIDATE: usize = 15;
+comptime ERROR_VARIABLE_REDECLARATION: usize = 16;
+comptime ERROR_RECURSIVE_TYPE: usize = 17;
+comptime ERROR_DUPLICATE_METHOD: usize = 18;
+comptime ERROR_BLANK_FOR_NULL: usize = 19;
+comptime ERROR_NON_PRIMITIVE_CAST: usize = 20;
+comptime ERROR_INDEXED_ACCESS_ON_NON_ARRAY: usize = 21;
+comptime ERROR_RUNTIME_VALUE_IN_COMPTIME_CONTEXT: usize = 22;
+comptime ERROR_ANY_DEREF: usize = 23;
+comptime ERROR_MEMBER_ACCESS_NON_STRUCT: usize = 24;
+comptime ERROR_MEMBER_ACCESS_TOO_MANY_OPTIONS: usize = 25;
+comptime ERROR_FUNCTION_CALL_TOO_MANY_OPTIONS: usize = 26;
 
 comptime TCSTATE_INVALID: usize = 0;
 comptime TCSTATE_ERROR: usize = 1;
@@ -484,59 +483,69 @@ func fillLookup(this: &TypeChecker) -> bool {
 
 func typeCheckModules(this: &TypeChecker) -> bool {
     trace("TypeChecker.typeCheckModules");
-    let done: bool = false;
-    let success: bool = true;
-    // FIXMEEEEEEE: After refactor of methods, this loop has to disappear
-    // We can simply check all structs first, then the function signatures
-    // and finally all functions, without that LOOKUP_NOT_READY stuff
-    while (!done) {
-        done = true;
-        for (let i: usize = 0; i < modules.length; i = i + 1) {
-            let mod: &ParsedModule = at(&modules, i);
-            assert(getID(mod) == i);
-            this.currentModule = i;
-            let currModule: &ModuleLookup = at(&this.lookup.modules, i);
-            assert(currModule.variables.length == 1, "still deez");
-            for (let j: usize = 0; j < mod.tliLength; j = j + 1) {
-                let tliID: usize = getTopLevelItemAtIndex(mod, j);
-                let tli: &ParsedTopLevelItem = at(&topLevelItems, tliID);
-                let state: TCState = typeCheckTLI(this, tli);
-                (*tli).typeState = state;
-                if (isError(&state)) {
-                    let err: usize = getError(&state);
-                    if (err == ERROR_LOOKUP_NOT_READY) {
-                        done = false;
-                        // break;
-                    } else if (isCriticalError(&state)) {
-                        // We can't continue here
-                        return false;
-                    } else {
-                        success = false;
-                    }
-                }
+    let success = true;
+    for (let i: usize = 0; i < modules.length; i = i + 1) {
+        let mod: &ParsedModule = at(&modules, i);
+        assert(getID(mod) == i);
+        this.currentModule = i;
+        for (let j: usize = 0; j < mod.tliLength; j = j + 1) {
+            let tliID: usize = getTopLevelItemAtIndex(mod, j);
+            let tli: &ParsedTopLevelItem = at(&topLevelItems, tliID);
+            if (tli.kind == TLI_STRUCT_DECL) {
+                let state = typeCheckStructDecl(this, tli.nodeID);
+                if (!isSuccess(&state)) success = false;
             }
         }
     }
-    return success;
-}
-
-func typeCheckTLI(this: &TypeChecker, tli: &ParsedTopLevelItem) -> TCState {
-    trace("TypeChecker.typeCheckTLI");
-    if (tli.ignored) return blank;
-    this.currentFunction = null;
-    let currentModule: &ModuleLookup = at(&this.lookup.modules, this.currentModule);
-    assert(currentModule.variables.length == 1, "expected to find only the global scope for TLI VarDecl");
-    if (tli.kind == TLI_IMPORT) {
-        return newTCStateSuccess();
-    } else if (tli.kind == TLI_FUNC_DECL) {
-        return typeCheckFunction(this, tli.nodeID, &currentModule.variables);
-    } else if (tli.kind == TLI_STRUCT_DECL) {
-        return typeCheckStructDecl(this, tli.nodeID);
-    } else if (tli.kind == TLI_VAR_DECL) {
-        return typeCheckVarDecl(this, tli.nodeID, &currentModule.variables, true);
-    } else {
-        unreachable("Exhaustive handling of TLI in typeCheckTLI");
+    if (!success) return false;
+    for (let i: usize = 0; i < modules.length; i = i + 1) {
+        let mod: &ParsedModule = at(&modules, i);
+        assert(getID(mod) == i);
+        this.currentModule = i;
+        let currentModule: &ModuleLookup = at(&this.lookup.modules, this.currentModule);
+        assert(currentModule.variables.length == 1, "expected to find only the global scope for TLI VarDecl");
+        for (let j: usize = 0; j < mod.tliLength; j = j + 1) {
+            let tliID: usize = getTopLevelItemAtIndex(mod, j);
+            let tli: &ParsedTopLevelItem = at(&topLevelItems, tliID);
+            if (tli.kind == TLI_FUNC_DECL) {
+                let state = typeCheckFunction(this, tli.nodeID, &currentModule.variables, true);
+                if (!isSuccess(&state)) success = false;
+            }
+        }
     }
+    if (!success) return false;
+    for (let i: usize = 0; i < modules.length; i = i + 1) {
+        let mod: &ParsedModule = at(&modules, i);
+        assert(getID(mod) == i);
+        this.currentModule = i;
+        let currentModule: &ModuleLookup = at(&this.lookup.modules, this.currentModule);
+        assert(currentModule.variables.length == 1, "expected to find only the global scope for TLI VarDecl");
+        for (let j: usize = 0; j < mod.tliLength; j = j + 1) {
+            let tliID: usize = getTopLevelItemAtIndex(mod, j);
+            let tli: &ParsedTopLevelItem = at(&topLevelItems, tliID);
+            if (tli.kind == TLI_VAR_DECL) {
+                let state = typeCheckVarDecl(this, tli.nodeID, &currentModule.variables, true);
+                if (!isSuccess(&state)) success = false;
+            }
+        }
+    }
+    if (!success) return false;
+    for (let i: usize = 0; i < modules.length; i = i + 1) {
+        let mod: &ParsedModule = at(&modules, i);
+        assert(getID(mod) == i);
+        this.currentModule = i;
+        let currentModule: &ModuleLookup = at(&this.lookup.modules, this.currentModule);
+        assert(currentModule.variables.length == 1, "expected to find only the global scope for TLI VarDecl");
+        for (let j: usize = 0; j < mod.tliLength; j = j + 1) {
+            let tliID: usize = getTopLevelItemAtIndex(mod, j);
+            let tli: &ParsedTopLevelItem = at(&topLevelItems, tliID);
+            if (tli.kind == TLI_FUNC_DECL) {
+                let state = typeCheckFunction(this, tli.nodeID, &currentModule.variables, false);
+                if (!isSuccess(&state)) success = false;
+            }
+        }
+    }
+    return true;
 }
 
 func typeCheckStructDecl(this: &TypeChecker, structID: usize) -> TCState {
@@ -574,7 +583,7 @@ func typeCheckStructDecl(this: &TypeChecker, structID: usize) -> TCState {
     return result;
 }
 
-func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupList) -> TCState {
+func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupList, signatureOnly: bool) -> TCState {
     trace("TypeChecker.typeCheckFunction");
     let function: &ParsedFuncDecl = at(&funcDecls, funcID);
     if (function.ignored) return blank;
@@ -615,6 +624,9 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
             setReadyState(funcLookup, FUNC_RETTYPE_COMPLETE);
         }
         setReadyState(funcLookup, FUNC_READY_TO_USE);
+    }
+    if (signatureOnly) {
+        return newTCStateSuccess();
     }
     (*function).typeState = newTCStateSuccess();
     if (!getReadyState(funcLookup, FUNC_DUPLICATE_CHECK)) {
@@ -661,12 +673,7 @@ func typeCheckBlock(this: &TypeChecker, blockID: usize, scopes: &ScopeLookupList
         let stmtState: TCState = typeCheckStmt(this, getStmtAtIndex(block, i), scopes);
         if (isError(&stmtState)) {
             let err: usize = getError(&stmtState);
-            if (err == ERROR_LOOKUP_NOT_READY) {
-                blockState = stmtState;
-                break;
-            } else {
-                blockState = stmtState;
-            }
+            blockState = stmtState;
         }
     }
     let after: usize = scopes.length;
@@ -1123,9 +1130,7 @@ func markFunctionCallCandidates(
     trace("TypeChecker.markFunctionCallCandidates");
     for (let i: usize = 0; i < functions.length; i = i + 1) {
         let f: &FunctionLookup = at(functions, i);
-        if (!getReadyState(f, FUNC_READY_TO_USE)) {
-            return newTCStateFailure(ERROR_LOOKUP_NOT_READY);
-        }
+        assert(getReadyState(f, FUNC_READY_TO_USE), "Function mark not ready");
         if (!f.isVarArg && f.params.length != arguments.length) {
             continue;
         }
@@ -1241,8 +1246,7 @@ func typeCheckExprStructInit(this: &TypeChecker, exprID: usize, scopes: &ScopeLo
     if (isStruct(&lookup)) {
         let context: &StructInitContext = &expr.structInitContext;
         let structLookup: &StructLookup = asStruct(&lookup);
-        if (!getReadyState(structLookup, STRUCT_FIELDS_COMPLETE))
-            return newTCStateFailure(ERROR_LOOKUP_NOT_READY);
+        assert(getReadyState(structLookup, STRUCT_FIELDS_COMPLETE), "Struct fields not ready pt2");
         let hits: usize = 0;
         assert(structLookup.fields.length < 50, "Sorry, I need to hack this for now");
         for (let i: usize = 0; i < context.fieldLength; i = i + 1) {
@@ -1304,9 +1308,7 @@ func typeCheckIdentifier(this: &TypeChecker, exprID: usize, scopes: &ScopeLookup
         reportRuntimeValueInComptimeContext(this, name, &var);
     }
     let state: TCState = var.typeState;
-    if (isInvalid(&state)) {
-        return newTCStateFailure(ERROR_LOOKUP_NOT_READY);
-    }
+    assert(!isInvalid(&state), "Variable not ready");
     if (isError(&state)) return state;
     assert(expr.op == 0);
     let _loc: Token = blank;
@@ -1481,8 +1483,7 @@ func typeCheckExprMemberAccess(this: &TypeChecker, dotID: usize, scopes: &ScopeL
         let structLookup: &StructLookup = asStruct(&lookup);
         let rhs: &ParsedExpr = at(&exprs, expr.rhs);
         assert(rhs.kind == EXPR_NAME);
-        if (!getReadyState(structLookup, STRUCT_FIELDS_COMPLETE))
-            return newTCStateFailure(ERROR_LOOKUP_NOT_READY);
+        assert(getReadyState(structLookup, STRUCT_FIELDS_COMPLETE), "Struct fields not complete");
         let fieldName: Token = rhs.origToken;
         let field: VariableLookup = blank;
         if (!resolveFieldByName(structLookup, &fieldName, &field)) {
@@ -1726,10 +1727,7 @@ func tryInferTypeOntoCall(this: &TypeChecker, exprID: usize, typeID: usize, chec
     let typ = at(&types, typeID);
     assert(expr.kind == EXPR_CALL);
     let functions: FunctionLookupList = blank;
-    if (!resolveAllFunctionsWithReturnType(&this.lookup, this.currentModule, &expr.origToken, typ, &functions)) {
-        clear(&functions);
-        return newTCStateFailure(ERROR_LOOKUP_NOT_READY);
-    }
+    assert(resolveAllFunctionsWithReturnType(&this.lookup, this.currentModule, &expr.origToken, typ, &functions), "Could not resolve functions");
     let callContext: &ArrayContext = &expr.arrayContext;
     let actual: FunctionLookupList = blank;
     for (let i: usize = 0; i < functions.length; i = i + 1) {

--- a/src/middleend/checker.bufo
+++ b/src/middleend/checker.bufo
@@ -1003,8 +1003,40 @@ func typeCheckExprAs(this: &TypeChecker, exprID: usize, scopes: &ScopeLookupList
     if (isError(&exprState)) return exprState;
     assert(isType(&exprState), "Expected <expr> in `<expr> as <type>` to have a valid type after infer");
     let exprType: &Type = at(&types, getType(&exprState));
-    if (isPointer(typeType) && isPointer(exprType)) {
+    if (isPointer(exprType) && isPointer(typeType)) {
         // PTR as PTR is allowed
+    } else if (isFunction(exprType) && isFunction(typeType)) {
+        // Function as Function is allowed
+        if (*flags.verbose) {
+            let loc = toString(&expr.span);
+            let from = toString(exprType);
+            let to = toString(typeType);
+            fprintf(stderr, "%s: %s: Casting from type %s to type %s.\n",
+                loc.buffer, WARN_STR, from.buffer, to.buffer);
+            drop(&to);
+            drop(&from);
+            drop(&loc);
+        }
+    } else if (isFunction(exprType) && isAny(typeType)) {
+        // Function as Any is allowed
+        if (*flags.verbose) {
+            let loc = toString(&expr.span);
+            let from = toString(typeType);
+            fprintf(stderr, "%s: %s: Casting from type %s to Any.\n",
+                loc.buffer, WARN_STR, from.buffer);
+            drop(&from);
+            drop(&loc);
+        }
+    } else if (isAny(exprType) && isFunction(typeType)) {
+        // Any as Function is allowed
+        if (*flags.verbose) {
+            let loc = toString(&expr.span);
+            let to = toString(typeType);
+            fprintf(stderr, "%s: %s: Casting from Any to type %s.\n",
+                loc.buffer, WARN_STR, to.buffer);
+            drop(&to);
+            drop(&loc);
+        }
     } else if (isPointer(exprType) && isInteger(typeType)) {
         if (getSize(typeType) != getSize(exprType)) {
             let loc = toString(&expr.span);

--- a/src/middleend/checker.bufo
+++ b/src/middleend/checker.bufo
@@ -556,29 +556,23 @@ func typeCheckStructDecl(this: &TypeChecker, structID: usize) -> TCState {
     let structLookup: &StructLookup = getStructByGlobalID(moduleLookup, structID);
     let context: &StructContext = &strukt.context;
     let result: TCState = newTCStateSuccess();
-    if (!getReadyState(structLookup, STRUCT_READY_TO_USE)) {
-        if (!getReadyState(structLookup, STRUCT_FIELDS_COMPLETE)) {
-            let failure: TCState = blank;
-            for (let i: usize = 0; i < context.fieldLength; i = i + 1) {
-                let name: Token = getFieldNameAtIndex(context, i);
-                let typ: usize = getFieldTypeAtIndex(context, i);
-                let dupl: VariableLookup = blank;
-                if (checkForDuplicateField(structLookup, &name, &dupl)) {
-                    failure = reportDuplicateField(this, name, dupl.name.span);
-                    continue;
-                }
-                let state: TCState = typeCheckTypeNode(this, typ);
-                if (isError(&state)) {
-                    failure = state;
-                    continue;
-                }
-                addField(structLookup, NODE_ID_OFFSET + i, name, state);
-            }
-            if (!isInvalid(&failure)) return failure;
-            setReadyState(structLookup, STRUCT_FIELDS_COMPLETE);
+    let failure: TCState = blank;
+    for (let i: usize = 0; i < context.fieldLength; i = i + 1) {
+        let name: Token = getFieldNameAtIndex(context, i);
+        let typ: usize = getFieldTypeAtIndex(context, i);
+        let dupl: VariableLookup = blank;
+        if (checkForDuplicateField(structLookup, &name, &dupl)) {
+            failure = reportDuplicateField(this, name, dupl.name.span);
+            continue;
         }
-        setReadyState(structLookup, STRUCT_READY_TO_USE);
+        let state: TCState = typeCheckTypeNode(this, typ);
+        if (isError(&state)) {
+            failure = state;
+            continue;
+        }
+        addField(structLookup, NODE_ID_OFFSET + i, name, state);
     }
+    if (!isInvalid(&failure)) return failure;
     (*strukt).typeState = newTCStateSuccess();
     return result;
 }
@@ -589,69 +583,48 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
     if (function.ignored) return blank;
     let moduleLookup: &ModuleLookup = at(&this.lookup.modules, this.currentModule);
     let funcLookup: &FunctionLookup = getFunctionByGlobalID(moduleLookup, funcID);
-    if (getReadyState(funcLookup, FUNC_BODY_COMPLETE)) {
-        assert(getReadyState(funcLookup, FUNC_READY_TO_USE), "Function should be ready to use at this point");
-        return function.typeState;
-    }
     this.currentFunction = funcLookup;
-    if (!getReadyState(funcLookup, FUNC_READY_TO_USE)) {
-        if (!getReadyState(funcLookup, FUNC_PARAMS_COMPLETE)) {
-            let failure: TCState = blank;
-            clear(&funcLookup.params);
-            for (let i: usize = 0; i < function.params.paramLength; i = i + 1) {
-                let typ: usize = getTypeAtIndex(&function.params, i);
-                let name: Token = getNameAtIndex(&function.params, i);
-                let dupl: VariableLookup = blank;
-                if (checkForDuplicateParam(funcLookup, &name, &dupl)) {
-                    failure = reportDuplicateParameter(this, name, dupl.name.span);
-                    setReadyState(funcLookup, FUNC_PARAMS_COMPLETE);
-                    continue;
-                }
-                let state: TCState = typeCheckTypeNode(this, typ);
-                if (isError(&state)) {
-                    failure = state;
-                    continue;
-                }
-                addParameter(funcLookup, NODE_ID_OFFSET + i, name, state);
-            }
-            if (!isInvalid(&failure)) return failure;
-            setReadyState(funcLookup, FUNC_PARAMS_COMPLETE);
+    let failure: TCState = blank;
+    clear(&funcLookup.params);
+    for (let i: usize = 0; i < function.params.paramLength; i = i + 1) {
+        let typ: usize = getTypeAtIndex(&function.params, i);
+        let name: Token = getNameAtIndex(&function.params, i);
+        let dupl: VariableLookup = blank;
+        if (checkForDuplicateParam(funcLookup, &name, &dupl)) {
+            failure = reportDuplicateParameter(this, name, dupl.name.span);
+            continue;
         }
-        if (!getReadyState(funcLookup, FUNC_RETTYPE_COMPLETE)) {
-            let retState: TCState = typeCheckTypeNode(this, function.retTypeID);
-            if (isError(&retState)) return retState;
-            setReturnType(funcLookup, retState);
-            setReadyState(funcLookup, FUNC_RETTYPE_COMPLETE);
+        let state: TCState = typeCheckTypeNode(this, typ);
+        if (isError(&state)) {
+            failure = state;
+            continue;
         }
-        setReadyState(funcLookup, FUNC_READY_TO_USE);
+        addParameter(funcLookup, NODE_ID_OFFSET + i, name, state);
     }
+    if (!isInvalid(&failure)) return failure;
+    let retState: TCState = typeCheckTypeNode(this, function.retTypeID);
+    if (isError(&retState)) return retState;
+    setReturnType(funcLookup, retState);
+    (*function).typeState = newTCStateSuccess();
     if (signatureOnly) {
         return newTCStateSuccess();
     }
-    (*function).typeState = newTCStateSuccess();
-    if (!getReadyState(funcLookup, FUNC_DUPLICATE_CHECK)) {
-        // FIXME: We need to use usize because the bootstrap doesn't support nested references :^)
-        let _dupl: usize = 0;
-        if (containsDuplicateFunction(moduleLookup, funcLookup, &_dupl)) {
-            assert(_dupl != 0, "Duplicate FunctionLookup is null");
-            return reportDuplicateFunction(this, funcLookup, _dupl as &FunctionLookup);
-        }
-        setReadyState(funcLookup, FUNC_DUPLICATE_CHECK);
+    let _dupl: &FunctionLookup = null;
+    if (containsDuplicateFunction(moduleLookup, funcLookup, &_dupl)) {
+        assert(_dupl != null, "Duplicate FunctionLookup is null");
+        return reportDuplicateFunction(this, funcLookup, _dupl);
     }
-    if (!getReadyState(funcLookup, FUNC_BODY_COMPLETE)) {
-        let scope: ScopeLookup = blank;
-        for (let i: usize = 0; i < funcLookup.params.length; i = i + 1) {
-            addVariable(&scope, *(at(&funcLookup.params, i)));
+    let scope: ScopeLookup = blank;
+    for (let i: usize = 0; i < funcLookup.params.length; i = i + 1) {
+        addVariable(&scope, *(at(&funcLookup.params, i)));
+    }
+    if (!isExtern(function)) {
+        push(scopes, scope);
+        let blockState: TCState = typeCheckBlock(this, function.body, scopes);
+        pop(scopes);
+        if (isError(&blockState)) {
+            return blockState;
         }
-        if (!isExtern(function)) {
-            push(scopes, scope);
-            let blockState: TCState = typeCheckBlock(this, function.body, scopes);
-            pop(scopes);
-            if (isError(&blockState)) {
-                return blockState;
-            }
-        }
-        setReadyState(funcLookup, FUNC_BODY_COMPLETE);
     }
     return function.typeState;
 }
@@ -744,7 +717,6 @@ func typeCheckStmt(this: &TypeChecker, stmtID: usize, scopes: &ScopeLookupList) 
         let exprState: TCState = typeCheckExpr(this, stmt.expr, scopes);
         if (isError(&exprState)) return exprState;
         assert(this.currentFunction != null);
-        assert(getReadyState(this.currentFunction, FUNC_READY_TO_USE), "Function is not ready");
         let _retType: &Type = at(&types, getType(&this.currentFunction.returnType));
         if (isNone(_retType)) todo_with_msg("unexpected ret expr where empty function");
         let retState: &TCState = &this.currentFunction.returnType;
@@ -764,7 +736,6 @@ func typeCheckStmt(this: &TypeChecker, stmtID: usize, scopes: &ScopeLookupList) 
         return newTCStateSuccess();
     } else if (stmt.kind == STMT_RETURN_EMPTY) {
         assert(this.currentFunction != null);
-        assert(getReadyState(this.currentFunction, FUNC_READY_TO_USE), "Function is not ready");
         let retType: &Type = at(&types, getType(&this.currentFunction.returnType));
         if (!isNone(retType)) {
             printf("%s\n", toString(&stmt.span).buffer);
@@ -1130,7 +1101,6 @@ func markFunctionCallCandidates(
     trace("TypeChecker.markFunctionCallCandidates");
     for (let i: usize = 0; i < functions.length; i = i + 1) {
         let f: &FunctionLookup = at(functions, i);
-        assert(getReadyState(f, FUNC_READY_TO_USE), "Function mark not ready");
         if (!f.isVarArg && f.params.length != arguments.length) {
             continue;
         }
@@ -1160,7 +1130,6 @@ func selectFunctionCallCandidate(
     }
     assert(candidates.length == 1, "selectFunctionCallCandidate: Expected exactly one candidate");
     let f: &FunctionLookup = at(candidates, 0);
-    assert(getReadyState(f, FUNC_READY_TO_USE), "Expected markFunctionCallCandidates to validate FUNC_READY_TO_USE");
     let paramCheck = typeCheckFunctionParameters(this, &f.params, callContext, arguments, false);
     if (isError(&paramCheck)) return paramCheck;
     *funcID = f.globalID;
@@ -1246,7 +1215,6 @@ func typeCheckExprStructInit(this: &TypeChecker, exprID: usize, scopes: &ScopeLo
     if (isStruct(&lookup)) {
         let context: &StructInitContext = &expr.structInitContext;
         let structLookup: &StructLookup = asStruct(&lookup);
-        assert(getReadyState(structLookup, STRUCT_FIELDS_COMPLETE), "Struct fields not ready pt2");
         let hits: usize = 0;
         assert(structLookup.fields.length < 50, "Sorry, I need to hack this for now");
         for (let i: usize = 0; i < context.fieldLength; i = i + 1) {
@@ -1483,7 +1451,6 @@ func typeCheckExprMemberAccess(this: &TypeChecker, dotID: usize, scopes: &ScopeL
         let structLookup: &StructLookup = asStruct(&lookup);
         let rhs: &ParsedExpr = at(&exprs, expr.rhs);
         assert(rhs.kind == EXPR_NAME);
-        assert(getReadyState(structLookup, STRUCT_FIELDS_COMPLETE), "Struct fields not complete");
         let fieldName: Token = rhs.origToken;
         let field: VariableLookup = blank;
         if (!resolveFieldByName(structLookup, &fieldName, &field)) {
@@ -1732,7 +1699,6 @@ func tryInferTypeOntoCall(this: &TypeChecker, exprID: usize, typeID: usize, chec
     let actual: FunctionLookupList = blank;
     for (let i: usize = 0; i < functions.length; i = i + 1) {
         let f = at(&functions, i);
-        assert(getReadyState(f, FUNC_PARAMS_COMPLETE));
         let arguments: TCStateList = blank;
         let state = typeCheckFunctionArguments(this, &f.params, callContext, &arguments, true);
         if (isError(&state)) {

--- a/src/middleend/checker.bufo
+++ b/src/middleend/checker.bufo
@@ -1881,7 +1881,23 @@ func typeCheckTypeNode(this: &TypeChecker, typeID: usize) -> TCState {
     if (typ.ignored) return blank;
     if (isSuccess(&typ.typeState)) return typ.typeState;
     let tid: usize = 0;
-    if (typ.kind == PARSED_TYPE_REF) {
+    if (typ.kind == PARSED_TYPE_FUNC) {
+        let retState: TCState = typeCheckTypeNode(this, typ.underlyingID);
+        if (isError(&retState)) return retState;
+        let params: TCStateList = blank;
+        let fnType = newType(TYPE_KIND_FUNCTION, getType(&retState));
+        let error: TCState = blank;
+        for (let i: usize = 0; i < typ.fnParams.length; i = i + 1) {
+            let state = typeCheckTypeNode(this, *at(&typ.fnParams, i));
+            if (isError(&state)) {
+                error = state;
+            }
+            push(&params, state);
+        }
+        if (isError(&error)) return error;
+        fnType.fnParams = params;
+        tid = getID(fnType);
+    } else if (typ.kind == PARSED_TYPE_REF) {
         let under: TCState = typeCheckTypeNode(this, typ.underlyingID);
         if (isError(&under)) return under;
         let underlyingType: usize = getType(&under);

--- a/src/middleend/checker.bufo
+++ b/src/middleend/checker.bufo
@@ -39,6 +39,7 @@ comptime ERROR_ANY_DEREF: usize = 23;
 comptime ERROR_MEMBER_ACCESS_NON_STRUCT: usize = 24;
 comptime ERROR_MEMBER_ACCESS_TOO_MANY_OPTIONS: usize = 25;
 comptime ERROR_FUNCTION_CALL_TOO_MANY_OPTIONS: usize = 26;
+comptime ERROR_CALL_TO_NON_FUNCTION: usize = 27;
 
 comptime TCSTATE_INVALID: usize = 0;
 comptime TCSTATE_ERROR: usize = 1;
@@ -242,7 +243,7 @@ func reportDuplicateFunction(this: &TypeChecker, f1: &FunctionLookup, f2: &Funct
 func reportNoFunctionCallCandidate(this: &TypeChecker, callID: usize, functions: &FunctionLookupList) -> TCState {
     trace("TypeChecker.reportNoFunctionCallCandidate");
     let callExpr: &ParsedExpr = at(&exprs, callID);
-    assert(callExpr.kind == EXPR_CALL, "reportNoFunctionCallCandidate: Expected expr to be a call");
+    assert(callExpr.kind == EXPR_NAME, "reportNoFunctionCallCandidate: Expected expr to be a call");
     let loc: String = toString(&callExpr.origToken.span);
     let name: String = toString(&callExpr.origToken.content);
     fprintf(stderr, "%s: %s: Could not find matching signature for call to function `%s`.\n", loc.buffer, ERR_STR, name.buffer);
@@ -385,6 +386,45 @@ func reportFunctionCallTooManyOptions(this: &TypeChecker, expr: &ParsedExpr, fun
     drop(&loc);
     this.typeError = true;
     return newTCStateFailure(ERROR_FUNCTION_CALL_TOO_MANY_OPTIONS);
+}
+
+func reportFunctionCallTooManyOptions(this: &TypeChecker, expr: &ParsedExpr) -> TCState {
+    trace("TypeChecker.reportFunctionCallTooManyOptions");
+    let loc = toString(&expr.span);
+    fprintf(stderr, "%s: %s: Could not infer which function to call.\n", loc.buffer, ERR_STR);
+    drop(&loc);
+    this.typeError = true;
+    return newTCStateFailure(ERROR_FUNCTION_CALL_TOO_MANY_OPTIONS);
+}
+
+func reportCallToNonFunction(this: &TypeChecker, span: Span, base: &Type) -> TCState {
+    trace("TypeChecker.reportCallToNonFunction");
+    let loc = toString(&span);
+    let typ = toString(base);
+    fprintf(stderr, "%s: %s: Can't call expression of type %s.\n", loc.buffer, ERR_STR, typ.buffer);
+    fprintf(stderr, "%s: %s: Currently, all variables (including global variables) shadow functions.\n", loc.buffer, NOTE_STR);
+    fprintf(stderr, "%s: %s: This is a known limitation and will be fixed soon.\n", loc.buffer, NOTE_STR);
+    drop(&typ);
+    drop(&loc);
+    this.typeError = true;
+    return newTCStateFailure(ERROR_CALL_TO_NON_FUNCTION);
+}
+
+func reportArgumentCountMismatch(this: &TypeChecker, span: Span, base: &Type, args: usize) -> TCState {
+    trace("TypeChecker.reportArgumentCountMismatch");
+    let loc = toString(&span);
+    let typ = toString(base);
+    let s = "arguments";
+    let c = base.fnParams.length;
+    if (c == 1) s = "argument";
+    let w = "were";
+    if (args == 1) w = "was";
+    fprintf(stderr, "%s: %s: Call expects %llu %s, but %llu %s provided.\n", loc.buffer, ERR_STR, c, s, args, w);
+    fprintf(stderr, "%s: %s: Call expression has type %s.\n", loc.buffer, NOTE_STR, typ.buffer);
+    drop(&typ);
+    drop(&loc);
+    this.typeError = true;
+    return newTCStateFailure(ERROR_CALL_TO_NON_FUNCTION);
 }
 
 func emergencyPrint(this: &TypeChecker, where: Span) {
@@ -586,7 +626,7 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
     this.currentFunction = funcLookup;
     let failure: TCState = blank;
     clear(&funcLookup.params);
-    let params: UsizeList = blank;
+    let params: TCStateList = blank;
     for (let i: usize = 0; i < function.params.paramLength; i = i + 1) {
         let typ: usize = getTypeAtIndex(&function.params, i);
         let name: Token = getNameAtIndex(&function.params, i);
@@ -600,7 +640,7 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
             failure = state;
             continue;
         }
-        push(&params, getType(&state));
+        push(&params, state);
         addParameter(funcLookup, NODE_ID_OFFSET + i, name, state);
     }
     if (!isInvalid(&failure)) return failure;
@@ -608,6 +648,8 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
     if (isError(&retState)) return retState;
     let fnType = newType(TYPE_KIND_FUNCTION, getType(&retState));
     fnType.fnParams = params;
+    if (function.params.isVarArg) fnType.arraySize = fnType.arraySize | FUNC_TYPE_VARIADIC;
+    if (hasAttribute(function, ATTR_NORETURN)) fnType.arraySize = fnType.arraySize | FUNC_TYPE_NORETURN;
     let state = newTCStateType(getID(fnType));
     funcLookup.fnType = state;
     function.typeState = state;
@@ -650,7 +692,6 @@ func typeCheckBlock(this: &TypeChecker, blockID: usize, scopes: &ScopeLookupList
     for (let i: usize = 0; i < block.stmtLength; i = i + 1) {
         let stmtState: TCState = typeCheckStmt(this, getStmtAtIndex(block, i), scopes);
         if (isError(&stmtState)) {
-            let err: usize = getError(&stmtState);
             blockState = stmtState;
         }
     }
@@ -668,7 +709,9 @@ func typeCheckStmt(this: &TypeChecker, stmtID: usize, scopes: &ScopeLookupList) 
     if (stmt.ignored) return blank;
     if (stmt.kind == STMT_BLOCK) {
         let blockState: TCState = typeCheckBlock(this, stmt.block, scopes);
-        if (isError(&blockState)) return blockState;
+        if (isError(&blockState)) {
+            return blockState;
+        }
         (*stmt).typeState = blockState;
         return blockState;
     } else if (stmt.kind == STMT_VAR_DECL) {
@@ -677,8 +720,13 @@ func typeCheckStmt(this: &TypeChecker, stmtID: usize, scopes: &ScopeLookupList) 
         if (isSuccess(&stmt.typeState))
             return stmt.typeState;
         let exprState: TCState = typeCheckExpr(this, stmt.expr, scopes);
-        if (isError(&exprState)) return exprState;
-        if (wantsInfer(&exprState)) todo_with_msg("stmt expr infer");
+        if (isError(&exprState)) {
+            return exprState;
+        }
+        if (wantsInfer(&exprState)) {
+            let noneType: &Type = newType(TYPE_KIND_PRIMITIVE, TYPE_NONE);
+            exprState = inferTypeOntoExpr(this, stmt.expr, getID(noneType));
+        }
         let expr: &ParsedExpr = at(&exprs, stmt.expr);
         if (!isType(&exprState)) {
             printf("%llu\n", exprState.kind);
@@ -1056,142 +1104,50 @@ func typeCheckExprCall(this: &TypeChecker, exprID: usize, scopes: &ScopeLookupLi
     // REVIEW: Would be cool if the call base could be any expression, not just an identifier
     let expr: &ParsedExpr = at(&exprs, exprID);
     assert(expr.kind == EXPR_CALL);
-    let name: Token = expr.origToken;
-    let functions: FunctionLookupList = resolveFunctionByName(&this.lookup, this.currentModule, &name);
-    if (functions.length == 0) {
-        let loc: String = getLocation(&name);
-        let n: String = toString(&name.content);
-        fprintf(stderr, "%s: %s: Call to unknown function `%s`.\n", loc.buffer, ERR_STR, n.buffer);
-        let alternatives: FunctionLookupList = searchAllModulesForFunctionName(&this.lookup, &name);
-        for (let i: usize = 0; i < alternatives.length; i = i + 1) {
-            let t: &FunctionLookup = at(&alternatives, i);
-            let loc: String = getLocation(&t.name);
-            fprintf(stderr, "%s: %s: A function with that name is located here. Import the module to use it.\n", loc.buffer, NOTE_STR);
-            drop(&loc);
-        }
-        drop(&n);
-        drop(&loc);
-        this.typeError = true;
-        return newTCStateFailure(ERROR_NO_SUCH_FUNCTION);
-    }
-    let callContext: &ArrayContext = &expr.arrayContext;
-    let arguments: TCStateList = blank;
+    // First sweep
+    let callContext = &expr.arrayContext;
     for (let i: usize = 0; i < callContext.elemLength; i = i + 1) {
         let argID: usize = getElementAtIndex(callContext, i);
         let arg: TCState = typeCheckExpr(this, argID, scopes);
         if (isError(&arg)) return arg;
-        push(&arguments, arg);
     }
-    assert(arguments.length == callContext.elemLength);
-    let candidates: FunctionLookupList = blank;
-    let mark: TCState = markFunctionCallCandidates(this, callContext, &functions, &candidates, &arguments);
-    if (isError(&mark)) return mark;
-    // functions contains all functions with the same amount of arguments and
-    // candidates where infer-semantics could validate the function
-    // e.g. foo(i: i32) + foo(i: u64) for foo(5)
-    let globalID: usize = 0;
-    let sweep: TCState = selectFunctionCallCandidate(this, exprID, callContext, &functions, &candidates, &arguments, &globalID);
-    if (isError(&sweep)) return sweep;
-    if (wantsInfer(&sweep)) return sweep;
-    assert(isType(&sweep));
-    (*expr).lhs = globalID;
-    return sweep;
-}
-
-func markFunctionCallCandidates(
-    this: &TypeChecker,
-    callContext: &ArrayContext,
-    functions: &FunctionLookupList,
-    candidates: &FunctionLookupList,
-    arguments: &TCStateList,
-) -> TCState {
-    trace("TypeChecker.markFunctionCallCandidates");
-    for (let i: usize = 0; i < functions.length; i = i + 1) {
-        let f: &FunctionLookup = at(functions, i);
-        if (!f.isVarArg && f.params.length != arguments.length) {
-            continue;
+    let callBase = typeCheckExpr(this, expr.lhs, scopes);
+    if (isError(&callBase)) return callBase;
+    if (wantsInfer(&callBase)) {
+        let fnType = newType(TYPE_KIND_FUNCTION, TYPE_UNKNOWN);
+        for (let i: usize = 0; i < callContext.elemLength; i = i + 1) {
+            let argID: usize = getElementAtIndex(callContext, i);
+            push(&fnType.fnParams, at(&exprs, argID).typeState);
         }
-        let paramCheck = typeCheckFunctionParameters(this, &f.params, callContext, arguments, true);
-        if (isError(&paramCheck)) {
-            continue;
-        }
-        push(candidates, *f);
+        let baseState = tryInferTypeOntoExpr(this, expr.lhs, getID(fnType), false);
+        if (isError(&baseState)) return baseState;
+        if (wantsInfer(&baseState)) return baseState;
+        callBase = baseState;
     }
-    return newTCStateSuccess();
-}
-
-func selectFunctionCallCandidate(
-    this: &TypeChecker,
-    exprID: usize,
-    callContext: &ArrayContext,
-    functions: &FunctionLookupList,
-    candidates: &FunctionLookupList,
-    arguments: &TCStateList,
-    funcID: &usize,
-) -> TCState {
-    trace("TypeChecker.selectFunctionCallCandidate");
-    if (candidates.length == 0) {
-        return reportNoFunctionCallCandidate(this, exprID, functions);
-    } else if (candidates.length > 1) {
-        return newTCStatePleaseInfer();
+    let baseType = at(&types, getType(&callBase));
+    if (!isFunction(baseType)) {
+        return reportCallToNonFunction(this, expr.span, baseType);
     }
-    assert(candidates.length == 1, "selectFunctionCallCandidate: Expected exactly one candidate");
-    let f: &FunctionLookup = at(candidates, 0);
-    let paramCheck = typeCheckFunctionParameters(this, &f.params, callContext, arguments, false);
-    if (isError(&paramCheck)) return paramCheck;
-    *funcID = f.globalID;
-    let retType: TCState = f.fnType;
-    assert(isSuccess(&retType), "selectFunctionCallCandidate: Expected valid function return type");
-    let rt = at(&types, getType(&retType));
-    return newTCStateType(rt.typeIndex);
-}
-
-func typeCheckFunctionArguments(this: &TypeChecker, params: &VariableLookupList, callContext: &ArrayContext, arguments: &TCStateList, checkOnly: bool) -> TCState {
-    trace("TypeChecker.typeCheckFunctionArguments");
-    if (params.length != callContext.elemLength) {
-        todo_with_msg("typeCheckFunctionArguments: param count mismatch");
+    if (!isVariadic(baseType) && callContext.elemLength != baseType.fnParams.length) {
+        return reportArgumentCountMismatch(this, expr.span, baseType, callContext.elemLength);
     }
-    for (let i: usize = 0; i < callContext.elemLength; i = i + 1) {
-        let param = at(params, i);
-        let pTypeID = getType(&param.typeState);
+    for (let i: usize = 0; i < baseType.fnParams.length; i = i + 1) {
         let argID: usize = getElementAtIndex(callContext, i);
-        let arg: TCState = tryInferTypeOntoExpr(this, argID, pTypeID, checkOnly);
-        if (isError(&arg)) {
-            todo_with_msg("typeCheckFunctionArguments: arg param couldnt infer");
+        let arg: TCState = typeCheckExpr(this, argID, scopes);
+        if (isError(&arg)) return arg;
+        if (wantsInfer(&arg)) {
+            let p = getParam(baseType, i);
+            arg = inferTypeOntoExpr(this, argID, getType(p));
+            if (isError(&arg)) return arg;
         }
-        push(arguments, arg);
-    }
-    assert(arguments.length == callContext.elemLength);
-    return newTCStateSuccess();
-}
-
-func typeCheckFunctionParameters(this: &TypeChecker, params: &VariableLookupList, callContext: &ArrayContext, arguments: &TCStateList, checkOnly: bool) -> TCState {
-    let succ = true;
-    for (let j: usize = 0; j < params.length; j = j + 1) {
-        let argState: TCState = *at(arguments, j);
-        let param: &VariableLookup = at(params, j);
-        let paramState: &TCState = &param.typeState;
-        assert(isSuccess(paramState), "Expected valid function parameter");
-        let paramType: &Type = at(&types, getType(paramState));
-        if (wantsInfer(&argState)) {
-            argState = tryInferTypeOntoExpr(this, getElementAtIndex(callContext, j), getID(paramType), checkOnly);
-            if (isError(&argState)) {
-                todo_with_msg("error when inferring type of param onto argument");
-            }
-            assert(isType(&argState), "Did not infer type of param onto argument properly");
-        }
-        let argType: &Type = at(&types, getType(&argState));
+        let argType = at(&types, getType(&arg));
+        let paramType = at(&types, getType(getParam(baseType, i)));
         if (!equals(argType, paramType)) {
-            if (!checkOnly) {
-                let e = at(&exprs, getElementAtIndex(callContext, j));
-                reportTypeMismatch(this, e.span, paramType, argType);
-            }
-            succ = false;
-            break;
+            let e = at(&exprs, argID);
+            reportTypeMismatch(this, e.span, paramType, argType);
         }
     }
-    if (!succ) return newTCStateFailure(ERROR_TYPE_MISMATCH);
-    return newTCStateSuccess();
+    return newTCStateType(baseType.typeIndex);
 }
 
 func typeCheckExprStructInit(this: &TypeChecker, exprID: usize, scopes: &ScopeLookupList) -> TCState {
@@ -1518,7 +1474,29 @@ func tryInferTypeOntoExpr(this: &TypeChecker, exprID: usize, typeID: usize, chec
     }
     let typ: &Type = at(&types, typeID);
     let tid: TCState = blank;
-    if (expr.kind == EXPR_INT_LIT) {
+    if (expr.kind == EXPR_NAME) {
+        assert(isFunction(typ), "Can only try to infer functions onto identifiers for now");
+        let functions = resolveAllFunctionsWithSignature(&this.lookup, this.currentModule, &expr.origToken, typ);
+        if (functions.length == 0) {
+            if (checkOnly) {
+                tid = newTCStateFailure(ERROR_NO_SUCH_FUNCTION);
+            } else {
+                let all = resolveFunctionByName(&this.lookup, this.currentModule, &expr.origToken);
+                tid = reportNoFunctionCallCandidate(this, exprID, &all);
+                drop(&all);
+            }
+        } else if (functions.length == 1) {
+            let f = at(&functions, 0);
+            assert(f.params.length == typ.fnParams.length);
+            if (!checkOnly) {
+                expr.lhs = f.globalID;
+            }
+            tid = f.fnType;
+        } else {
+            tid = newTCStatePleaseInfer();
+        }
+        drop(&functions);
+    } else if (expr.kind == EXPR_INT_LIT) {
         if (isChar(typ)) {
             if (!checkOnly) {
                 let l: String = getLocation(&expr.origToken);
@@ -1713,44 +1691,35 @@ func tryInferTypeOntoCall(this: &TypeChecker, exprID: usize, typeID: usize, chec
     let typ = at(&types, typeID);
     assert(expr.kind == EXPR_CALL);
     let functions: FunctionLookupList = blank;
-    assert(resolveAllFunctionsWithReturnType(&this.lookup, this.currentModule, &expr.origToken, typ, &functions), "Could not resolve functions");
-    let callContext: &ArrayContext = &expr.arrayContext;
-    let actual: FunctionLookupList = blank;
-    for (let i: usize = 0; i < functions.length; i = i + 1) {
-        let f = at(&functions, i);
-        let arguments: TCStateList = blank;
-        let state = typeCheckFunctionArguments(this, &f.params, callContext, &arguments, true);
-        if (isError(&state)) {
-            todo_with_msg("argument fail");
-        }
-        state = typeCheckFunctionParameters(this, &f.params, callContext, &arguments, checkOnly);
-        if (isError(&state)) {
-            todo_with_msg("parameter fail");
-        }
-        push(&actual, *f);
+    let fnType = newType(TYPE_KIND_FUNCTION, typeID);
+    let callContext = &expr.arrayContext;
+    for (let i: usize = 0; i < callContext.elemLength; i = i + 1) {
+        let argID: usize = getElementAtIndex(callContext, i);
+        push(&fnType.fnParams, at(&exprs, argID).typeState);
     }
-    if (actual.length == 1) {
-        let f = at(&actual, 0);
-        if (!checkOnly) {
-            let arguments: TCStateList = blank;
-            let state = typeCheckFunctionArguments(this, &f.params, callContext, &arguments, false);
-            assert(isSuccess(&state));
-            (*expr).lhs = f.globalID;
-        }
-        let _rt = at(&types, getType(&f.fnType));
-        return newTCStateType(_rt.typeIndex);
-    } else if (actual.length == 0) {
-        if (!checkOnly) {
-            let functions: FunctionLookupList = resolveFunctionByName(&this.lookup, this.currentModule, &expr.origToken);
-            return reportNoFunctionCallCandidate(this, getID(expr), &functions);
-        }
-        return newTCStateFailure(ERROR_TYPE_MISMATCH);
-    } else {
-        if (!checkOnly) {
-            return reportFunctionCallTooManyOptions(this, expr, &actual);
-        }
-        return newTCStateFailure(ERROR_TYPE_MISMATCH);
+    let baseState = tryInferTypeOntoExpr(this, expr.lhs, getID(fnType), checkOnly);
+    if (isError(&baseState)) return baseState;
+    if (wantsInfer(&baseState)) {
+        return reportFunctionCallTooManyOptions(this, expr);
     }
+    assert(isType(&baseState), "tryInferOntoCall: Base is not a type");
+    let baseFunc = at(&types, getType(&baseState));
+    assert(isFunction(baseFunc), "tryInferTypeOntoCall: Base is not a function");
+    assert(baseFunc.typeIndex == typeID, "tryInferTypeOntoCall: Base return type doesn't match expected");
+    assert(baseFunc.fnParams.length == callContext.elemLength, "tryInferTypeOntoCall: Base expects different count of arguments");
+    let state: TCState = newTCStateSuccess();
+    for (let i: usize = 0; i < callContext.elemLength; i = i + 1) {
+        let p = getParam(baseFunc, i);
+        let s1 = tryInferTypeOntoExpr(this, getElementAtIndex(callContext, i), getType(p), checkOnly);
+        if (isError(&s1)) {
+            state = s1;
+        }
+    }
+    if (!isSuccess(&state)) {
+        todo_with_msg("infer arg failed");
+    }
+    if (checkOnly) return newTCStateSuccess();
+    return newTCStateType(typeID);
 }
 
 func tryInferTypeOntoMemberAccess(this: &TypeChecker, exprID: usize, typeID: usize, checkOnly: bool) -> TCState {

--- a/src/middleend/checker.bufo
+++ b/src/middleend/checker.bufo
@@ -586,6 +586,7 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
     this.currentFunction = funcLookup;
     let failure: TCState = blank;
     clear(&funcLookup.params);
+    let params: UsizeList = blank;
     for (let i: usize = 0; i < function.params.paramLength; i = i + 1) {
         let typ: usize = getTypeAtIndex(&function.params, i);
         let name: Token = getNameAtIndex(&function.params, i);
@@ -599,13 +600,17 @@ func typeCheckFunction(this: &TypeChecker, funcID: usize, scopes: &ScopeLookupLi
             failure = state;
             continue;
         }
+        push(&params, getType(&state));
         addParameter(funcLookup, NODE_ID_OFFSET + i, name, state);
     }
     if (!isInvalid(&failure)) return failure;
     let retState: TCState = typeCheckTypeNode(this, function.retTypeID);
     if (isError(&retState)) return retState;
-    setReturnType(funcLookup, retState);
-    (*function).typeState = newTCStateSuccess();
+    let fnType = newType(TYPE_KIND_FUNCTION, getType(&retState));
+    fnType.fnParams = params;
+    let state = newTCStateType(getID(fnType));
+    funcLookup.fnType = state;
+    function.typeState = state;
     if (signatureOnly) {
         return newTCStateSuccess();
     }
@@ -717,18 +722,18 @@ func typeCheckStmt(this: &TypeChecker, stmtID: usize, scopes: &ScopeLookupList) 
         let exprState: TCState = typeCheckExpr(this, stmt.expr, scopes);
         if (isError(&exprState)) return exprState;
         assert(this.currentFunction != null);
-        let _retType: &Type = at(&types, getType(&this.currentFunction.returnType));
-        if (isNone(_retType)) todo_with_msg("unexpected ret expr where empty function");
-        let retState: &TCState = &this.currentFunction.returnType;
+        let retState: &TCState = &this.currentFunction.fnType;
         assert(isSuccess(retState), "ready to use function has invalid return type");
         assert(isType(retState), "ready to use function has non-type as return type");
+        let _rt = at(&types, getType(retState));
+        let retType = at(&types, _rt.typeIndex);
+        if (isNone(retType)) todo_with_msg("unexpected ret expr where empty function");
         if (wantsInfer(&exprState)) {
-            exprState = inferTypeOntoExpr(this, stmt.expr, getType(retState));
+            exprState = inferTypeOntoExpr(this, stmt.expr, getID(retType));
             if (isError(&exprState)) return exprState;
             assert(isType(&exprState), "Failed to infer type of return expression");
         }
         let exprType: &Type = at(&types, getType(&exprState));
-        let retType: &Type = at(&types, getType(retState));
         if (!equals(exprType, retType)) {
             return reportTypeMismatch(this, stmt.span, retType, exprType);
         }
@@ -736,7 +741,9 @@ func typeCheckStmt(this: &TypeChecker, stmtID: usize, scopes: &ScopeLookupList) 
         return newTCStateSuccess();
     } else if (stmt.kind == STMT_RETURN_EMPTY) {
         assert(this.currentFunction != null);
-        let retType: &Type = at(&types, getType(&this.currentFunction.returnType));
+        let retState: &TCState = &this.currentFunction.fnType;
+        let _rt = at(&types, getType(retState));
+        let retType = at(&types, _rt.typeIndex);
         if (!isNone(retType)) {
             printf("%s\n", toString(&stmt.span).buffer);
             printf("%llu %llu\n", retType.kind, retType.typeIndex);
@@ -1133,9 +1140,10 @@ func selectFunctionCallCandidate(
     let paramCheck = typeCheckFunctionParameters(this, &f.params, callContext, arguments, false);
     if (isError(&paramCheck)) return paramCheck;
     *funcID = f.globalID;
-    let retType: TCState = f.returnType;
+    let retType: TCState = f.fnType;
     assert(isSuccess(&retType), "selectFunctionCallCandidate: Expected valid function return type");
-    return retType;
+    let rt = at(&types, getType(&retType));
+    return newTCStateType(rt.typeIndex);
 }
 
 func typeCheckFunctionArguments(this: &TypeChecker, params: &VariableLookupList, callContext: &ArrayContext, arguments: &TCStateList, checkOnly: bool) -> TCState {
@@ -1256,36 +1264,47 @@ func typeCheckIdentifier(this: &TypeChecker, exprID: usize, scopes: &ScopeLookup
     assert(expr.kind == EXPR_NAME);
     let name: Token = expr.origToken;
     let var: VariableLookup = blank;
-    if (!resolveVariableByName(&this.lookup, this.currentModule, &name, scopes, &var)) {
-        let loc: String = getLocation(&name);
-        let _name: String = toString(&name.content);
-        fprintf(stderr, "%s: %s: Use of undeclared identifier `%s`.\n", loc.buffer, ERR_STR, _name.buffer);
-        let alternatives: VariableLookupList = searchAllModulesForIdentifier(&this.lookup, &name);
-        for (let i: usize = 0; i < alternatives.length; i = i + 1) {
-            let t: &VariableLookup = at(&alternatives, i);
-            let loc: String = getLocation(&t.name);
-            fprintf(stderr, "%s: %s: A variable with that name is located here. Import the module to use it.\n", loc.buffer, NOTE_STR);
-            drop(&loc);
+    if (resolveVariableByName(&this.lookup, this.currentModule, &name, scopes, &var)) {
+        if (this.isComptimeContext && !var.isComptime) {
+            reportRuntimeValueInComptimeContext(this, name, &var);
         }
-        drop(&_name);
-        drop(&loc);
-        this.typeError = true;
-        return newTCStateFailure(ERROR_NO_SUCH_IDENTIFIER);
+        let state: TCState = var.typeState;
+        assert(!isInvalid(&state), "Variable not ready");
+        if (isError(&state)) return state;
+        assert(expr.op == 0);
+        let _loc: Token = blank;
+        if (isKnownVariable(at(scopes, 0), name.content, &_loc)) {
+            (*expr).op = 1;
+        }
+        (*expr).lhs = var.globalID;
+        (*expr).typeState = state;
+        return state;
+    } else {
+        let functions = resolveFunctionByName(&this.lookup, this.currentModule, &name);
+        if (functions.length == 0) {
+            let loc: String = getLocation(&name);
+            let _name: String = toString(&name.content);
+            fprintf(stderr, "%s: %s: Use of undeclared identifier `%s`.\n", loc.buffer, ERR_STR, _name.buffer);
+            let alternatives: VariableLookupList = searchAllModulesForIdentifier(&this.lookup, &name);
+            for (let i: usize = 0; i < alternatives.length; i = i + 1) {
+                let t: &VariableLookup = at(&alternatives, i);
+                let loc: String = getLocation(&t.name);
+                fprintf(stderr, "%s: %s: A variable with that name is located here. Import the module to use it.\n", loc.buffer, NOTE_STR);
+                drop(&loc);
+            }
+            drop(&_name);
+            drop(&loc);
+            this.typeError = true;
+            return newTCStateFailure(ERROR_NO_SUCH_IDENTIFIER);
+        } else if (functions.length == 1) {
+            let f = at(&functions, 0);
+            (*expr).lhs = f.globalID;
+            (*expr).typeState = f.fnType;
+            return f.fnType;
+        } else {
+            return newTCStatePleaseInfer();
+        }
     }
-    if (this.isComptimeContext && !var.isComptime) {
-        reportRuntimeValueInComptimeContext(this, name, &var);
-    }
-    let state: TCState = var.typeState;
-    assert(!isInvalid(&state), "Variable not ready");
-    if (isError(&state)) return state;
-    assert(expr.op == 0);
-    let _loc: Token = blank;
-    if (isKnownVariable(at(scopes, 0), name.content, &_loc)) {
-        (*expr).op = 1;
-    }
-    (*expr).lhs = var.globalID;
-    (*expr).typeState = state;
-    return state;
 }
 
 func typeCheckExprBinary(this: &TypeChecker, binID: usize, scopes: &ScopeLookupList) -> TCState {
@@ -1718,7 +1737,8 @@ func tryInferTypeOntoCall(this: &TypeChecker, exprID: usize, typeID: usize, chec
             assert(isSuccess(&state));
             (*expr).lhs = f.globalID;
         }
-        return f.returnType;
+        let _rt = at(&types, getType(&f.fnType));
+        return newTCStateType(_rt.typeIndex);
     } else if (actual.length == 0) {
         if (!checkOnly) {
             let functions: FunctionLookupList = resolveFunctionByName(&this.lookup, this.currentModule, &expr.origToken);

--- a/src/middleend/lookup.bufo
+++ b/src/middleend/lookup.bufo
@@ -201,8 +201,8 @@ func insertTLI(this: &ModuleLookup, tli: &ParsedTopLevelItem) {
             globalID: tli.nodeID,
             parentModule: this.globalID,
             name: fun.name,
-            returnType: blank,
             params: blank,
+            fnType: blank,
             isVarArg: fun.params.isVarArg,
         };
         push(&this.functions, lookup);
@@ -308,8 +308,9 @@ func resolveAllFunctionsWithReturnType(this: &ModuleLookup, name: &Token, typ: &
         if (!equals(&f.name.content, &name.content)) {
             continue;
         }
-        let t = at(&types, getType(&f.returnType));
-        if (equals(t, typ)) {
+        let _rt = at(&types, getType(&f.fnType));
+        let retType = at(&types, _rt.typeIndex);
+        if (equals(retType, typ)) {
             push(list, *f);
         }
     }
@@ -357,14 +358,9 @@ struct FunctionLookup {
     globalID: usize;
     parentModule: usize;
     name: Token;
-    returnType: TCState;
+    fnType: TCState;
     params: VariableLookupList;
     isVarArg: bool;
-}
-
-func setReturnType(this: &FunctionLookup, typ: TCState) {
-    trace("FunctionLookup.setReturnType");
-    this.returnType = typ;
 }
 
 func addParameter(this: &FunctionLookup, globalID: usize, name: Token, typeState: TCState) {

--- a/src/middleend/lookup.bufo
+++ b/src/middleend/lookup.bufo
@@ -203,7 +203,6 @@ func insertTLI(this: &ModuleLookup, tli: &ParsedTopLevelItem) {
             name: fun.name,
             returnType: blank,
             params: blank,
-            readyState: FUNC_INCOMPLETE,
             isVarArg: fun.params.isVarArg,
         };
         push(&this.functions, lookup);
@@ -223,7 +222,6 @@ func insertTLI(this: &ModuleLookup, tli: &ParsedTopLevelItem) {
             globalID: tli.nodeID,
             parentModule: this.globalID,
             name: strukt.name,
-            readyState: STRUCT_INCOMPLETE,
             fields: blank,
             typeID: getID(newType(TYPE_KIND_STRUCT, tli.nodeID)),
         };
@@ -252,19 +250,16 @@ func insertTLI(this: &ModuleLookup, tli: &ParsedTopLevelItem) {
     }
 }
 
-// FIXME: We need to use usize because the bootstrap doesn't support nested references :^)
-func containsDuplicateFunction(this: &ModuleLookup, function: &FunctionLookup, dupl: &usize) -> bool {
+func containsDuplicateFunction(this: &ModuleLookup, function: &FunctionLookup, dupl: &&FunctionLookup) -> bool {
     trace("ModuleLookup.containsDuplicateFunction");
     let name: String = getMangledName(at(&funcDecls, function.globalID));
     let duplicate: bool = false;
     for (let i: usize = 0; !duplicate && i < this.functions.length; i = i + 1) {
         let f: &FunctionLookup = at(&this.functions, i);
-        // REVIEW: is FUNC_DUPLICATE_CHECK always correct, or is it better to check FUNC_READY_TO_USE
         if (f == function) continue;
-        if (!getReadyState(f, FUNC_DUPLICATE_CHECK)) continue;
         let n: String = getMangledName(at(&funcDecls, f.globalID));
         if (equals(&name, &n)) {
-            *dupl = f as usize;
+            *dupl = f;
             duplicate = true;
         }
         drop(&n);
@@ -310,9 +305,6 @@ func resolveAllFunctionsWithReturnType(this: &ModuleLookup, name: &Token, typ: &
     trace("ModuleLookup.resolveAllFunctionsWithReturnType");
     for (let i: usize = 0; i < this.functions.length; i = i + 1) {
         let f: &FunctionLookup = at(&this.functions, i);
-        if (!getReadyState(f, FUNC_RETTYPE_COMPLETE)) {
-            return false;
-        }
         if (!equals(&f.name.content, &name.content)) {
             continue;
         }
@@ -361,29 +353,13 @@ func equals(this: &ImportLookup, other: &ImportLookup) -> bool {
     return this.moduleID == other.moduleID;
 }
 
-comptime FUNC_INCOMPLETE       : usize = pow2(0);
-comptime FUNC_ERROR            : usize = pow2(1);
-comptime FUNC_PARAMS_COMPLETE  : usize = pow2(2);
-comptime FUNC_RETTYPE_COMPLETE : usize = pow2(3);
-comptime FUNC_READY_TO_USE     : usize = pow2(4);
-comptime FUNC_DUPLICATE_CHECK  : usize = pow2(5);
-comptime FUNC_BODY_COMPLETE    : usize = pow2(6);
 struct FunctionLookup {
     globalID: usize;
     parentModule: usize;
     name: Token;
     returnType: TCState;
     params: VariableLookupList;
-    readyState: usize;
     isVarArg: bool;
-}
-
-func getReadyState(this: &FunctionLookup, state: usize) -> bool {
-    return (this.readyState & state) != 0;
-}
-func setReadyState(this: &FunctionLookup, state: usize) {
-    assert(!getReadyState(this, state), "FunctionLookup.readyState is already set");
-    this.readyState = this.readyState | state;
 }
 
 func setReturnType(this: &FunctionLookup, typ: TCState) {
@@ -466,27 +442,12 @@ func newTypeLookup(kind: usize, actual: Any) -> TypeLookup {
     };
 }
 
-comptime STRUCT_INCOMPLETE        : usize = pow2(0);
-comptime STRUCT_ERROR             : usize = pow2(1);
-comptime STRUCT_FIELDS_COMPLETE   : usize = pow2(2);
-comptime STRUCT_SIGNATURE_COMPLETE: usize = pow2(3);
-comptime STRUCT_METHODS_COMPLETE  : usize = pow2(4);
-comptime STRUCT_READY_TO_USE      : usize = pow2(5);
 struct StructLookup {
     globalID: usize;
     parentModule: usize;
     name: Token;
-    readyState: usize;
     fields: VariableLookupList;
     typeID: usize;
-}
-
-func getReadyState(this: &StructLookup, state: usize) -> bool {
-    return (this.readyState & state) != 0;
-}
-func setReadyState(this: &StructLookup, state: usize) {
-    assert(!getReadyState(this, state), "StructLookup.readyState is already set");
-    this.readyState = this.readyState | state;
 }
 
 func asTypeLookup(this: &StructLookup) -> TypeLookup {

--- a/src/middleend/lookup.bufo
+++ b/src/middleend/lookup.bufo
@@ -1,4 +1,5 @@
 import "prelude.bufo";
+import "libc.bufo";
 import "substr.bufo";
 import "string.bufo";
 import "../util/span.bufo";
@@ -45,21 +46,18 @@ func resolveFunctionByName(this: &Lookup, currentModule: usize, name: &Token) ->
     return list;
 }
 
-func resolveAllFunctionsWithReturnType(this: &Lookup, currentModule: usize, name: &Token, typ: &Type, list: &FunctionLookupList) -> bool {
-    trace("Lookup.resolveAllFunctionsWithReturnType");
+func resolveAllFunctionsWithSignature(this: &Lookup, currentModule: usize, name: &Token, typ: &Type) -> FunctionLookupList {
+    trace("Lookup.resolveAllFunctionsWithSignature");
     // FIXME: Would be cool if this method didn't create copies of the FunctionLookups
     let currModule: &ModuleLookup = at(&this.modules, currentModule);
-    if (!resolveAllFunctionsWithReturnType(currModule, name, typ, list)) {
-        return false;
-    }
+    let list: FunctionLookupList = blank;
+    extend(&list, &resolveAllFunctionsWithSignature(currModule, name, typ));
     for (let i: usize = 0; i < currModule.imports.length; i = i + 1) {
         let imp: &ImportLookup = at(&currModule.imports, i);
         let importedModule: &ModuleLookup = at(&this.modules, imp.moduleID);
-        if (!resolveAllFunctionsWithReturnType(importedModule, name, typ, list)) {
-            return false;
-        }
+        extend(&list, &resolveAllFunctionsWithSignature(importedModule, name, typ));
     }
-    return true;
+    return list;
 }
 
 func resolveAllStructsWithField(this: &Lookup, currentModule: usize, name: &Token, typ: &Type) -> StructLookupList {
@@ -301,20 +299,59 @@ func resolveFunctionByName(this: &ModuleLookup, name: &Token) -> FunctionLookupL
     return list;
 }
 
-func resolveAllFunctionsWithReturnType(this: &ModuleLookup, name: &Token, typ: &Type, list: &FunctionLookupList) -> bool {
-    trace("ModuleLookup.resolveAllFunctionsWithReturnType");
+func resolveAllFunctionsWithSignature(this: &ModuleLookup, name: &Token, typ: &Type) -> FunctionLookupList {
+    trace("ModuleLookup.resolveAllFunctionsWithSignature");
+    let list: FunctionLookupList = blank;
+    assert(isFunction(typ), "resolveAllFunctionsWithSignature called with non-function type signature");
     for (let i: usize = 0; i < this.functions.length; i = i + 1) {
         let f: &FunctionLookup = at(&this.functions, i);
         if (!equals(&f.name.content, &name.content)) {
             continue;
         }
         let _rt = at(&types, getType(&f.fnType));
-        let retType = at(&types, _rt.typeIndex);
-        if (equals(retType, typ)) {
-            push(list, *f);
+        assert(isFunction(_rt));
+        if (typ.fnParams.length != _rt.fnParams.length) continue;
+        let retType1 = at(&types, typ.typeIndex);
+        let retType2 = at(&types, _rt.typeIndex);
+        if (PRINT_DEBUG) {
+            let s1 = toString(retType1);
+            let s2 = toString(retType2);
+            printf("[DEBUG] Return Type 1: %s\n", s1.buffer);
+            printf("[DEBUG] Return Type 2: %s\n", s2.buffer);
+            drop(&s2);
+            drop(&s1);
+        }
+        if (!isUnknown(retType1)) if (!equals(retType1, retType2)) {
+            debug("Not adding: return type mismatch");
+            continue;
+        }
+        let succ = true;
+        for (let j: usize = 0; j < typ.fnParams.length; j = j + 1) {
+            let p1 = getParam(typ, j);
+            let p2 = getParam(_rt, j);
+            if (!isType(p1)) continue;
+            let t1 = at(&types, getType(p1));
+            let t2 = at(&types, getType(p2));
+            if (PRINT_DEBUG) {
+                let s1 = toString(t1);
+                let s2 = toString(t2);
+                printf("[DEBUG] Type 1: %s\n", s1.buffer);
+                printf("[DEBUG] Type 2: %s\n", s2.buffer);
+                drop(&s2);
+                drop(&s1);
+            }
+            if (!isUnknown(t1)) if (!equals(t1, t2)) {
+                debug("Not adding function");
+                succ = false;
+                break;
+            }
+        }
+        if (succ) {
+            debug("adding function");
+            push(&list, *f);
         }
     }
-    return true;
+    return list;
 }
 
 func resolveAllStructsWithField(this: &ModuleLookup, name: &Token, typ: &Type) -> StructLookupList {

--- a/src/middleend/types.bufo
+++ b/src/middleend/types.bufo
@@ -2,9 +2,10 @@ import "prelude.bufo";
 import "libc.bufo";
 import "string.bufo";
 import "substr.bufo";
+import "../util/arena.bufo";
+import "../util/lists.bufo";
 import "../frontend/nodes.bufo";
 import "../frontend/context.bufo";
-import "../util/arena.bufo";
 import "./checker.bufo";
 
 func nextMultipleOf(a: usize, b: usize) -> usize {
@@ -38,9 +39,11 @@ comptime TYPE_KIND_PRIMITIVE: usize = 1;
 comptime TYPE_KIND_POINTER: usize = 2;
 comptime TYPE_KIND_STRUCT: usize = 3;
 comptime TYPE_KIND_ARRAY: usize = 4;
+comptime TYPE_KIND_FUNCTION: usize = 5;
 struct Type {
     kind: usize;
     typeIndex: usize;
+    fnParams: UsizeList;
     arraySize: usize;
 }
 
@@ -77,6 +80,18 @@ func getMangledName(this: &Type) -> String {
         if (hash < 100) pushNumber(&s, 0);
         pushNumber(&s, hash);
         return s;
+    } else if (this.kind == TYPE_KIND_FUNCTION) {
+        let s: String = newStringFromStrLit("F");
+        let r = getMangledName(at(&types, this.typeIndex));
+        pushString(&s, &r);
+        drop(&r);
+        for (let i: usize = 0; i < this.fnParams.length; i = i + 1) {
+            if (i != this.fnParams.length - 1) pushChar(&s, '.');
+            let p = getMangledName(at(&types, *at(&this.fnParams, i)));
+            pushString(&s, &p);
+            drop(&p);
+        }
+        return s;
     } else if (this.kind == TYPE_KIND_ARRAY) {
         todo_with_msg("mangled type array");
     } else if (this.kind == TYPE_KIND_UNKNOWN) {
@@ -106,6 +121,19 @@ func equals(this: &Type, other: &Type) -> bool {
         return false;
     if (this.kind == TYPE_KIND_ARRAY) {
         return equals(at(&types, this.typeIndex), at(&types, other.typeIndex));
+    }
+    if (this.kind == TYPE_KIND_FUNCTION) {
+        if (this.fnParams.length != other.fnParams.length)
+            return false;
+        if (!equals(at(&types, this.typeIndex), at(&types, other.typeIndex)))
+            return false;
+        for (let i: usize = 0; i < this.fnParams.length; i = i + 1) {
+            let p1 = at(&types, *at(&this.fnParams, i));
+            let p2 = at(&types, *at(&other.fnParams, i));
+            if (!equals(p1, p2))
+                return false;
+        }
+        return true;
     }
     if (this.kind == TYPE_KIND_PRIMITIVE
         || this.kind == TYPE_KIND_ARRAY
@@ -155,6 +183,9 @@ func isAny(this: &Type) -> bool {
 }
 func isPrimitive(this: &Type) -> bool {
     return this.kind == TYPE_KIND_PRIMITIVE;
+}
+func isFunction(this: &Type) -> bool {
+    return this.kind == TYPE_KIND_FUNCTION;
 }
 func isPointer(this: &Type) -> bool {
     if (this.kind == TYPE_KIND_POINTER) return true;
@@ -219,6 +250,26 @@ func toString(this: &Type) -> String {
     } else if (this.kind == TYPE_KIND_STRUCT) {
         let decl: &ParsedStructDecl = at(&structDecls, this.typeIndex);
         return toString(&decl.name.content);
+    } else if (this.kind == TYPE_KIND_FUNCTION) {
+        let s: String = newStringFromStrLit("func (");
+        for (let i: usize = 0; i < this.fnParams.length; i = i + 1) {
+            let p = toString(at(&types, *at(&this.fnParams, i)));
+            pushString(&s, &p);
+            drop(&p);
+            if (i != this.fnParams.length - 1) {
+                pushChar(&s, ',');
+                pushChar(&s, ' ');
+            }
+        }
+        pushChar(&s, ')');
+        let rt = at(&types, this.typeIndex);
+        if (!isNone(rt)) {
+            pushStr(&s, " -> ");
+            let r = toString(rt);
+            pushString(&s, &r);
+            drop(&r);
+        }
+        return s;
     } else if (this.kind == TYPE_KIND_ARRAY) {
         let s: String = newStringFromStrLit("[");
         let _s: String = toString(at(&types, this.typeIndex));
@@ -232,7 +283,7 @@ func toString(this: &Type) -> String {
     } else if (this.kind == TYPE_KIND_UNKNOWN) {
         return newStringFromStrLit("<unknown>");
     } else {
-        unreachable("Exhaustive handling of types in Type.getMangledName");
+        unreachable("Exhaustive handling of types in Type.toString");
     }
 }
 func getAlignment(this: &Type) -> usize {
@@ -278,6 +329,8 @@ func getAlignment(this: &Type) -> usize {
 }
 func getSize(this: &Type) -> usize {
     if (this.kind == TYPE_KIND_POINTER) {
+        return 8;
+    } else if (this.kind == TYPE_KIND_FUNCTION) {
         return 8;
     } else if (this.kind == TYPE_KIND_PRIMITIVE) {
         if (this.typeIndex == TYPE_UNKNOWN) unreachable("Type.getSize(TYPE_UNKNOWN) called");

--- a/src/middleend/types.bufo
+++ b/src/middleend/types.bufo
@@ -93,7 +93,12 @@ func getMangledName(this: &Type) -> String {
         }
         return s;
     } else if (this.kind == TYPE_KIND_ARRAY) {
-        todo_with_msg("mangled type array");
+        let s: String = newStringFromStrLit("A");
+        let r = getMangledName(at(&types, this.typeIndex));
+        pushString(&s, &r);
+        drop(&r);
+        pushNumber(&s, this.arraySize);
+        return s;
     } else if (this.kind == TYPE_KIND_UNKNOWN) {
         todo_with_msg("mangled type unknown???");
     } else {
@@ -311,6 +316,8 @@ func toString(this: &Type) -> String {
 }
 func getAlignment(this: &Type) -> usize {
     if (this.kind == TYPE_KIND_POINTER) {
+        return 8;
+    } else if (this.kind == TYPE_KIND_FUNCTION) {
         return 8;
     } else if (this.kind == TYPE_KIND_PRIMITIVE) {
         if (this.typeIndex == TYPE_UNKNOWN) unreachable("Type.getAlignment(TYPE_UNKNOWN) called");

--- a/src/middleend/types.bufo
+++ b/src/middleend/types.bufo
@@ -43,7 +43,7 @@ comptime TYPE_KIND_FUNCTION: usize = 5;
 struct Type {
     kind: usize;
     typeIndex: usize;
-    fnParams: UsizeList;
+    fnParams: TCStateList;
     arraySize: usize;
 }
 
@@ -87,7 +87,7 @@ func getMangledName(this: &Type) -> String {
         drop(&r);
         for (let i: usize = 0; i < this.fnParams.length; i = i + 1) {
             if (i != this.fnParams.length - 1) pushChar(&s, '.');
-            let p = getMangledName(at(&types, *at(&this.fnParams, i)));
+            let p = getMangledName(at(&types, getType(at(&this.fnParams, i))));
             pushString(&s, &p);
             drop(&p);
         }
@@ -128,8 +128,8 @@ func equals(this: &Type, other: &Type) -> bool {
         if (!equals(at(&types, this.typeIndex), at(&types, other.typeIndex)))
             return false;
         for (let i: usize = 0; i < this.fnParams.length; i = i + 1) {
-            let p1 = at(&types, *at(&this.fnParams, i));
-            let p2 = at(&types, *at(&other.fnParams, i));
+            let p1 = at(&types, getType(at(&this.fnParams, i)));
+            let p2 = at(&types, getType(at(&other.fnParams, i)));
             if (!equals(p1, p2))
                 return false;
         }
@@ -142,6 +142,9 @@ func equals(this: &Type, other: &Type) -> bool {
     todo_with_msg("Type.equals");
 }
 
+func isUnknown(this: &Type) -> bool {
+    return this.kind == TYPE_KIND_UNKNOWN;
+}
 func isFloat(this: &Type) -> bool {
     if (this.kind != TYPE_KIND_PRIMITIVE) return false;
     return this.typeIndex == TYPE_F32
@@ -187,6 +190,16 @@ func isPrimitive(this: &Type) -> bool {
 func isFunction(this: &Type) -> bool {
     return this.kind == TYPE_KIND_FUNCTION;
 }
+comptime FUNC_TYPE_VARIADIC: usize = pow2(0);
+comptime FUNC_TYPE_NORETURN: usize = pow2(1);
+func isVariadic(this: &Type) -> bool {
+    if (!isFunction(this)) return false;
+    return (this.arraySize & FUNC_TYPE_VARIADIC) != 0;
+}
+func isNoreturn(this: &Type) -> bool {
+    if (!isFunction(this)) return false;
+    return (this.arraySize & FUNC_TYPE_NORETURN) != 0;
+}
 func isPointer(this: &Type) -> bool {
     if (this.kind == TYPE_KIND_POINTER) return true;
     if (this.kind == TYPE_KIND_PRIMITIVE)
@@ -223,6 +236,7 @@ func getUnderlyingType(this: &Type, deep: bool) -> &Type {
     return underlying;
 }
 func toString(this: &Type) -> String {
+    trace("Type.toString");
     if (this.kind == TYPE_KIND_PRIMITIVE) {
         // OPT: Make these Strings comptime
         if (this.typeIndex == TYPE_U8) return newStringFromStrLit("u8");
@@ -253,13 +267,22 @@ func toString(this: &Type) -> String {
     } else if (this.kind == TYPE_KIND_FUNCTION) {
         let s: String = newStringFromStrLit("func (");
         for (let i: usize = 0; i < this.fnParams.length; i = i + 1) {
-            let p = toString(at(&types, *at(&this.fnParams, i)));
+            let param = at(&this.fnParams, i);
+            let p: String = blank;
+            if (isType(param)) {
+                p = toString(at(&types, getType(param)));
+            } else {
+                p = newStringFromStrLit("<unknown>");
+            }
             pushString(&s, &p);
             drop(&p);
             if (i != this.fnParams.length - 1) {
                 pushChar(&s, ',');
                 pushChar(&s, ' ');
             }
+        }
+        if (isVariadic(this)) {
+            pushStr(&s, "...");
         }
         pushChar(&s, ')');
         let rt = at(&types, this.typeIndex);
@@ -373,6 +396,11 @@ func getSize(this: &Type) -> usize {
     } else {
         unreachable("Exhaustive handling of type kinds in Type.getSize");
     }
+}
+func getParam(fnType: &Type, id: usize) -> &TCState {
+    assert(isFunction(fnType), "getParam() called on non-function type");
+    assert(id < fnType.fnParams.length, "Out of bounds access in getParam()");
+    return at(&fnType.fnParams, id);
 }
 func getMaxFloatValue(this: &Type) -> f64 {
     assert(isFloat(this), "Type.getMaxFloatValue() called on non-Float");

--- a/src/util/lists.bufo
+++ b/src/util/lists.bufo
@@ -12,8 +12,114 @@ import "../backend/LLVM/basic_block.bufo";
 import "../backend/LLVM/values.bufo";
 import "../backend/LLVM/types.bufo";
 
+// TODO: Generics would be cool :Clueless:
 struct ModuleLookupList {
     elements: &ModuleLookup;
+    length: usize;
+    capacity: usize;
+}
+struct ParsedAttributeList {
+    elements: &ParsedAttribute;
+    length: usize;
+    capacity: usize;
+}
+struct FunctionLookupList {
+    elements: &FunctionLookup;
+    length: usize;
+    capacity: usize;
+}
+struct StructLookupList {
+    elements: &StructLookup;
+    length: usize;
+    capacity: usize;
+}
+struct ScopeLookupList {
+    elements: &ScopeLookup;
+    length: usize;
+    capacity: usize;
+}
+struct TypeLookupList {
+    elements: &TypeLookup;
+    length: usize;
+    capacity: usize;
+}
+struct VariableLookupList {
+    elements: &VariableLookup;
+    length: usize;
+    capacity: usize;
+}
+struct ImportLookupList {
+    elements: &ImportLookup;
+    length: usize;
+    capacity: usize;
+}
+struct TCStateList {
+    elements: &TCState;
+    length: usize;
+    capacity: usize;
+}
+struct RegIndexList {
+    elements: &RegIndex;
+    length: usize;
+    capacity: usize;
+}
+struct IRInstrList {
+    elements: &IRInstr;
+    length: usize;
+    capacity: usize;
+}
+struct IRScopeList {
+    elements: &IRScope;
+    length: usize;
+    capacity: usize;
+}
+struct IRRegList {
+    elements: &IRReg;
+    length: usize;
+    capacity: usize;
+}
+struct IRBlockList {
+    elements: &IRBlock;
+    length: usize;
+    capacity: usize;
+}
+struct LoopBlockList {
+    elements: &LoopBlock;
+    length: usize;
+    capacity: usize;
+}
+struct IRScopeEntryList {
+    elements: &IRScopeEntry;
+    length: usize;
+    capacity: usize;
+}
+struct IRFuncList {
+    elements: &IRFunc;
+    length: usize;
+    capacity: usize;
+}
+struct LLVMTypeList {
+    elements: &LLVMType;
+    length: usize;
+    capacity: usize;
+}
+struct RegValueList {
+    elements: &RegValue;
+    length: usize;
+    capacity: usize;
+}
+struct LLVMBasicBlockList {
+    elements: &LLVMBasicBlock;
+    length: usize;
+    capacity: usize;
+}
+struct LLVMValueList {
+    elements: &LLVMValue;
+    length: usize;
+    capacity: usize;
+}
+struct UsizeList {
+    elements: &usize;
     length: usize;
     capacity: usize;
 }
@@ -82,12 +188,6 @@ func clear(this: &ModuleLookupList) {
     this.length = 0;
 }
 
-struct ParsedAttributeList {
-    elements: &ParsedAttribute;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &ParsedAttributeList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof ParsedAttribute);
@@ -150,12 +250,6 @@ func drop(this: &ParsedAttributeList) {
 
 func clear(this: &ParsedAttributeList) {
     this.length = 0;
-}
-
-struct FunctionLookupList {
-    elements: &FunctionLookup;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &FunctionLookupList, newCap: usize) {
@@ -222,12 +316,6 @@ func clear(this: &FunctionLookupList) {
     this.length = 0;
 }
 
-struct StructLookupList {
-    elements: &StructLookup;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &StructLookupList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof StructLookup);
@@ -290,12 +378,6 @@ func drop(this: &StructLookupList) {
 
 func clear(this: &StructLookupList) {
     this.length = 0;
-}
-
-struct ScopeLookupList {
-    elements: &ScopeLookup;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &ScopeLookupList, newCap: usize) {
@@ -362,12 +444,6 @@ func clear(this: &ScopeLookupList) {
     this.length = 0;
 }
 
-struct TypeLookupList {
-    elements: &TypeLookup;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &TypeLookupList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof TypeLookup);
@@ -430,12 +506,6 @@ func drop(this: &TypeLookupList) {
 
 func clear(this: &TypeLookupList) {
     this.length = 0;
-}
-
-struct VariableLookupList {
-    elements: &VariableLookup;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &VariableLookupList, newCap: usize) {
@@ -502,12 +572,6 @@ func clear(this: &VariableLookupList) {
     this.length = 0;
 }
 
-struct ImportLookupList {
-    elements: &ImportLookup;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &ImportLookupList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof ImportLookup);
@@ -570,12 +634,6 @@ func drop(this: &ImportLookupList) {
 
 func clear(this: &ImportLookupList) {
     this.length = 0;
-}
-
-struct TCStateList {
-    elements: &TCState;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &TCStateList, newCap: usize) {
@@ -642,12 +700,6 @@ func clear(this: &TCStateList) {
     this.length = 0;
 }
 
-struct RegIndexList {
-    elements: &RegIndex;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &RegIndexList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof RegIndex);
@@ -710,12 +762,6 @@ func drop(this: &RegIndexList) {
 
 func clear(this: &RegIndexList) {
     this.length = 0;
-}
-
-struct IRInstrList {
-    elements: &IRInstr;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &IRInstrList, newCap: usize) {
@@ -782,12 +828,6 @@ func clear(this: &IRInstrList) {
     this.length = 0;
 }
 
-struct IRScopeList {
-    elements: &IRScope;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &IRScopeList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof IRScope);
@@ -850,12 +890,6 @@ func drop(this: &IRScopeList) {
 
 func clear(this: &IRScopeList) {
     this.length = 0;
-}
-
-struct IRRegList {
-    elements: &IRReg;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &IRRegList, newCap: usize) {
@@ -922,12 +956,6 @@ func clear(this: &IRRegList) {
     this.length = 0;
 }
 
-struct IRBlockList {
-    elements: &IRBlock;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &IRBlockList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof IRBlock);
@@ -990,12 +1018,6 @@ func drop(this: &IRBlockList) {
 
 func clear(this: &IRBlockList) {
     this.length = 0;
-}
-
-struct LoopBlockList {
-    elements: &LoopBlock;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &LoopBlockList, newCap: usize) {
@@ -1062,12 +1084,6 @@ func clear(this: &LoopBlockList) {
     this.length = 0;
 }
 
-struct IRScopeEntryList {
-    elements: &IRScopeEntry;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &IRScopeEntryList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof IRScopeEntry);
@@ -1130,12 +1146,6 @@ func drop(this: &IRScopeEntryList) {
 
 func clear(this: &IRScopeEntryList) {
     this.length = 0;
-}
-
-struct IRFuncList {
-    elements: &IRFunc;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &IRFuncList, newCap: usize) {
@@ -1202,12 +1212,6 @@ func clear(this: &IRFuncList) {
     this.length = 0;
 }
 
-struct LLVMTypeList {
-    elements: &LLVMType;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &LLVMTypeList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof LLVMType);
@@ -1270,12 +1274,6 @@ func drop(this: &LLVMTypeList) {
 
 func clear(this: &LLVMTypeList) {
     this.length = 0;
-}
-
-struct RegValueList {
-    elements: &RegValue;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &RegValueList, newCap: usize) {
@@ -1342,12 +1340,6 @@ func clear(this: &RegValueList) {
     this.length = 0;
 }
 
-struct LLVMBasicBlockList {
-    elements: &LLVMBasicBlock;
-    length: usize;
-    capacity: usize;
-}
-
 func initBlank(this: &LLVMBasicBlockList, newCap: usize) {
     if (this.elements != null) free(this.elements);
     this.elements = calloc(newCap, sizeof LLVMBasicBlock);
@@ -1410,12 +1402,6 @@ func drop(this: &LLVMBasicBlockList) {
 
 func clear(this: &LLVMBasicBlockList) {
     this.length = 0;
-}
-
-struct LLVMValueList {
-    elements: &LLVMValue;
-    length: usize;
-    capacity: usize;
 }
 
 func initBlank(this: &LLVMValueList, newCap: usize) {
@@ -1482,3 +1468,20 @@ func clear(this: &LLVMValueList) {
     this.length = 0;
 }
 
+func push(this: &UsizeList, element: usize) {
+    if (this.length >= this.capacity) {
+        let newCap: usize = this.capacity * 2;
+        if (newCap == 0) newCap = 32;
+        this.elements = realloc(this.elements, newCap * sizeof usize);
+        assert(this.elements != null, "Could not allocate memory in UsizeList.push");
+        this.capacity = newCap;
+    }
+    this.elements[this.length] = element;
+    this.length = this.length + 1;
+}
+
+func at(this: &UsizeList, index: usize) -> &usize {
+    assert(index < this.length, "Out of bounds access in UsizeList.at");
+    assert(this.elements != null, "Element pointer is NULL in UsizeList.at");
+    return &this.elements[index];
+}

--- a/std/prelude.bufo
+++ b/std/prelude.bufo
@@ -192,6 +192,7 @@ func assert(cond: bool, msg: &char) {
     exit(1);
 }
 
+// FIXMEEEEEEE: Make this CLI flags
 comptime PRINT_DEBUG: bool = false;
 func debug(msg: &char) {
     if (!PRINT_DEBUG) return;

--- a/tests/comptime/ackermann.bufo
+++ b/tests/comptime/ackermann.bufo
@@ -15,7 +15,7 @@ func main(argc: i32, argv: &&char) -> i32 {
     comptime n: usize = 2;
     comptime v1: usize = ack(m, n);
     assert(v1 == 29);
-    comptime v2: usize = ack(3, 5);
-    assert(v2 == 253);
+    comptime v2: usize = ack(3, 4);
+    assert(v2 == 125);
     return 0;
 }

--- a/tests/misc/0010-func_type_mismatch.bufo
+++ b/tests/misc/0010-func_type_mismatch.bufo
@@ -1,0 +1,21 @@
+//! THIS IS A TEST PROGRAM
+//! COMPILER
+//! FAILURE
+//! CODE: 1
+//! ERROR:
+//! Type mismatch! Expected type func () -> i32, found type func (i32) -> i8.
+//! Array elements inferred to be type func () -> i32 here.
+
+func foo() -> i32 {
+    return 1;
+}
+
+func bar(a: i32) -> i8 {
+    return 0;
+}
+
+func main(argc: i32, argv: &&char) -> i32 {
+    let f = [foo, bar];
+    return 0;
+}
+

--- a/tests/misc/0011-func_array.bufo
+++ b/tests/misc/0011-func_array.bufo
@@ -1,0 +1,38 @@
+//! THIS IS A TEST PROGRAM
+//! RUNTIME
+//! SUCCESS
+
+import "prelude.bufo";
+
+func foo() -> i32 {
+    return 8;
+}
+
+func bar() -> i32 {
+    return 12;
+}
+
+func baz() -> i32 {
+    return 17;
+}
+
+func main(argc: i32, argv: &&char) -> i32 {
+    let fns = [
+        foo,
+        bar,
+        baz,
+        baz,
+        bar,
+    ];
+    let truth: [i32; 5] = [
+        8,
+        12,
+        17,
+        17,
+        12,
+    ];
+    for (let i: usize = 0; i < 5; i = i + 1) {
+        assert(fns[i]() == truth[i]);
+    }
+    return 0;
+}

--- a/tests/misc/0025-func_infer_many.bufo
+++ b/tests/misc/0025-func_infer_many.bufo
@@ -4,8 +4,6 @@
 //! CODE: 1
 //! ERROR:
 //! Could not infer which function to call.
-//! Context allows this function to be called.
-//! Context allows this function to be called.
 //! Could not find matching signature for call to function `foo`.
 //! A function with that name is located here.
 //! A function with that name is located here.

--- a/tests/misc/0028-func_array_comptime.bufo
+++ b/tests/misc/0028-func_array_comptime.bufo
@@ -1,0 +1,38 @@
+//! THIS IS A TEST PROGRAM
+//! RUNTIME
+//! SUCCESS
+
+import "prelude.bufo";
+
+func foo() -> i32 {
+    return 8;
+}
+
+func bar() -> i32 {
+    return 12;
+}
+
+func baz() -> i32 {
+    return 17;
+}
+
+func main(argc: i32, argv: &&char) -> i32 {
+    comptime fns = [
+        foo,
+        bar,
+        baz,
+        baz,
+        bar,
+    ];
+    let truth: [i32; 5] = [
+        8,
+        12,
+        17,
+        17,
+        12,
+    ];
+    for (let i: usize = 0; i < 5; i = i + 1) {
+        assert(fns[i]() == truth[i]);
+    }
+    return 0;
+}

--- a/tests/misc/0029-func_type.bufo
+++ b/tests/misc/0029-func_type.bufo
@@ -1,0 +1,21 @@
+//! THIS IS A TEST PROGRAM
+//! RUNTIME
+//! SUCCESS
+
+import "prelude.bufo";
+
+func foo() -> i32 {
+    return 1;
+}
+
+func foo() -> u8 {
+    return 2;
+}
+
+func main(argc: i32, argv: &&char) -> i32 {
+    let f: func () -> u8 = foo;
+    let a = f();
+    assert(a == 2);
+    return 0;
+}
+

--- a/tests/misc/0030-func_param.bufo
+++ b/tests/misc/0030-func_param.bufo
@@ -1,0 +1,28 @@
+//! THIS IS A TEST PROGRAM
+//! RUNTIME
+//! SUCCESS
+
+import "prelude.bufo";
+import "libc.bufo";
+
+func square(n: i32) -> i32 {
+    return n * n;
+}
+
+func map(a: [i32; 5], f: func (i32) -> i32) -> [i32; 5] {
+    let new: [i32; 5] = blank;
+    for (let i: usize = 0; i < 5; i = i + 1) {
+        new[i] = f(a[i]);
+    }
+    return new;
+}
+
+func main(argc: i32, argv: &&char) -> i32 {
+    let values: [i32; 5] = [1, 2, 3, 4, 5];
+    let squares = map(values, square);
+    for (let i: usize = 0; i < 5; i = i + 1) {
+        assert(values[i] * values[i] == squares[i]);
+    }
+    return 0;
+}
+

--- a/tests/misc/0031-func_struct.bufo
+++ b/tests/misc/0031-func_struct.bufo
@@ -1,0 +1,21 @@
+//! THIS IS A TEST PROGRAM
+//! RUNTIME
+//! SUCCESS
+
+import "prelude.bufo";
+
+func square(n: i32) -> i32 {
+    return n * n;
+}
+
+struct Foo {
+    f: func (i32) -> i32;
+}
+
+func main(argc: i32, argv: &&char) -> i32 {
+    let f = Foo { f: square };
+    let a = f.f(10);
+    assert(a == 100);
+    return 0;
+}
+

--- a/tests/semantics/type_mismatch_in_fn_args.bufo
+++ b/tests/semantics/type_mismatch_in_fn_args.bufo
@@ -9,6 +9,9 @@
 func foo(a: u64) {
 }
 
+func foo(a: i16) {
+}
+
 func bar(a: i32) {
 }
 

--- a/tests/syntax/extra_arguments_in_func_call.bufo
+++ b/tests/syntax/extra_arguments_in_func_call.bufo
@@ -3,8 +3,8 @@
 //! FAILURE
 //! CODE: 1
 //! ERROR:
-//! Could not find matching signature for call to function `bla`.
-//! A function with that name is located here.
+//! Call expects 1 argument, but 2 were provided.
+//! Call expression has type func (i32).
 
 func bla(a: i32) {
 

--- a/tests/syntax/missing_arguments_in_func_call.bufo
+++ b/tests/syntax/missing_arguments_in_func_call.bufo
@@ -3,8 +3,8 @@
 //! FAILURE
 //! CODE: 1
 //! ERROR:
-//! Could not find matching signature for call to function `bla`.
-//! A function with that name is located here.
+//! Call expects 3 arguments, but 2 were provided.
+//! Call expression has type func (i32, i32, i32).
 
 func bla(a: i32, b: i32, c: i32) {
 }


### PR DESCRIPTION
We can now use function pointers to do fancy things in bufo, like passing callbacks or storing variables in arrays or other data types. This does not add support for anonymous functions, only pre-existing functions or casts from Any (e.g. dlsym) can be used. Even without support for closures, this marks a big milestone in the language progress.