### PR TITLE
Add temporary syntax highlighting for .bufo files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bufo linguist-language=Rust


### PR DESCRIPTION
This adds a `.gitattributes` file which highlights `.bufo` files with Rust syntax highlighting, since it has the most similar syntax (other than some different keywords like `func`)

In theory, this would be temporary until Bufo can get its own linguist language entry for GitHub, which is relatively difficult as the requirements include [at least several dozens of independent repositories using Bufo](https://github.com/github-linguist/linguist/blob/main/CONTRIBUTING.md#language-extension-and-filename-usage-requirements).